### PR TITLE
kcc namespaces solution

### DIFF
--- a/solutions/kcc-namespaces/Kptfile
+++ b/solutions/kcc-namespaces/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: kcc-namespaces
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.1
+      configPath: setters.yaml

--- a/solutions/kcc-namespaces/README.md
+++ b/solutions/kcc-namespaces/README.md
@@ -1,0 +1,26 @@
+# kcc-namespaces solution
+
+## Description
+This solution is a simple fork of the KCC Project Namespaces blueprint found at
+https://cloud.google.com/anthos-config-management/docs/tutorials/project-namespace-blueprint
+
+This simple solution will great a dedicated namespace to manage your GCP resources in a certain project. The namespace and project-id will be match for simplicity. This solution assumes that you storing all high-level resources in the `config-control` namespsace.
+
+Also, this solution grants the GCP Service Account that KCC uses to create resources in the tenant project the `Owner` role. This is a very broad role and it is recommend that you update the `kcc-project-owner.yaml` file to specify only the roles that are required to create the resources you wish. This will adopt the principal of least privilege.
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] guardrails`
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree guardrails`
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init kcc-namespaces
+kpt live apply kcc-namespaces --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/solutions/kcc-namespaces/kcc-namespace-viewer.yaml
+++ b/solutions/kcc-namespaces/kcc-namespace-viewer.yaml
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Give KCC for this project's namespace permission to read KCC resources in the projects namespace.
+# This allows IAMMemberPolicy in this project's namespace to reference the project in the projects namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: projects/cnrm-project-viewer-project-id
+  name: cnrm-project-viewer-MY_AWESOME_PROJECT_0000 # kpt-set: cnrm-project-viewer-${project-id}
+  namespace: config-control
+roleRef:
+  name: cnrm-viewer
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: cnrm-controller-manager-MY_AWESOME_PROJECT_0000 # kpt-set: cnrm-controller-manager-${project-id}
+    namespace: cnrm-system
+    kind: ServiceAccount

--- a/solutions/kcc-namespaces/kcc-project-owner.yaml
+++ b/solutions/kcc-namespaces/kcc-project-owner.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Grant KCC owner of this project
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata: # kpt-merge: projects/kcc-project-id-owners-permissions
+  name: kcc-MY_AWESOME_PROJECT_0000-owners-permissions # kpt-set: kcc-${project-id}-owners-permissions
+  namespace: config-control
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.4.1,kpt-fn-live
+    cnrm.cloud.google.com/project-id: MGMT_PROJECT_ID_0000 # kpt-set: ${management-project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: MY_AWESOME_PROJECT_0000 # kpt-set: ${project-id}
+  bindings:
+    - role: roles/owner
+      members:
+        - member: serviceAccount:kcc-MY_AWESOME_PROJECT_0000@MGMT_PROJECT_ID_0000.iam.gserviceaccount.com # kpt-set: serviceAccount:kcc-${project-id}@${management-project-id}.iam.gserviceaccount.com

--- a/solutions/kcc-namespaces/kcc.yaml
+++ b/solutions/kcc-namespaces/kcc.yaml
@@ -1,0 +1,53 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Enable KCC for this namespace
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata: # kpt-merge: project-id/configconnectorcontext.core.cnrm.cloud.google.com
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: MY_AWESOME_PROJECT_0000 # kpt-set: ${project-id}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.4.1,kpt-fn-live
+spec:
+  googleServiceAccount: kcc-MY_AWESOME_PROJECT_0000@MGMT_PROJECT_ID_0000.iam.gserviceaccount.com # kpt-set: kcc-${project-id}@${management-project-id}.iam.gserviceaccount.com
+---
+# Create GCP ServiceAccount for use by KCC to manage resources in this project
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata: # kpt-merge: config-control/kcc-project-id
+  name: kcc-MY_AWESOME_PROJECT_0000 # kpt-set: kcc-${project-id}
+  namespace: config-control # kpt-set: ${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.4.1,kpt-fn-live
+    cnrm.cloud.google.com/project-id: MGMT_PROJECT_ID_0000 # kpt-set: ${management-project-id}
+spec:
+  displayName: kcc-MY_AWESOME_PROJECT_0000 # kpt-set: kcc-${project-id}
+---
+# Allow KCC's Kubernetes Service Account to use the GCP ServiceAccount
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata: # kpt-merge: config-control/project-id-sa-workload-identity-binding
+  name: MY_AWESOME_PROJECT_0000-sa-workload-identity-binding # kpt-set: ${project-id}-sa-workload-identity-binding
+  namespace: config-control # kpt-set: ${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.4.1,kpt-fn-live
+spec:
+  resourceRef:
+    name: kcc-MY_AWESOME_PROJECT_0000 # kpt-set: kcc-${project-id}
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member: serviceAccount:MGMT_PROJECT_ID_0000.svc.id.goog[cnrm-system/cnrm-controller-manager-MY_AWESOME_PROJECT_0000] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-${project-id}]

--- a/solutions/kcc-namespaces/namespace.yaml
+++ b/solutions/kcc-namespaces/namespace.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Create namespace in the Kubernetes cluster to manage KCC resources in this project
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /project-id
+  name: MY_AWESOME_PROJECT_0000 # kpt-set: ${project-id}
+  annotations:
+    cnrm.cloud.google.com/project-id: MY_AWESOME_PROJECT_0000 # kpt-set: ${project-id}

--- a/solutions/kcc-namespaces/project-admin.yaml
+++ b/solutions/kcc-namespaces/project-admin.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: project-admin
+  namespace: MY_AWESOME_PROJECT_0000 # kpt-set: ${project-id}
+roleRef:
+  kind: ClusterRole
+  name: cnrm-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: User
+  name: admins@shaunmitchell.altostrat.com # kpt-set: ${admin-user}
+  apiGroup: rbac.authorization.k8s.io

--- a/solutions/kcc-namespaces/setters.yaml
+++ b/solutions/kcc-namespaces/setters.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata: # kpt-merge: /setters
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  management-namespace: config-control
+  management-project-id: MGMT_PROJECT_ID_0000 # This is the project-id where config controller resides
+  project-id: MY_AWESOME_PROJECT_0000 # This is the project-id where you want KCC to deploy resource to

--- a/solutions/kcc-namespaces/validation.yaml
+++ b/solutions/kcc-namespaces/validation.yaml
@@ -1,0 +1,48 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: fn.kpt.dev/v1alpha1
+kind: StarlarkRun
+metadata: # kpt-merge: /validate-project-ns
+  name: validate-project-ns
+  annotations:
+    config.kubernetes.io/local-config: 'true'
+source: |
+  def get_tenant_ns(resource_list):
+    for resource in resource_list["items"]:
+      if resource["kind"] == "Namespace":
+        return resource["metadata"]["name"]
+    fail("unable to find tenant project namespace")
+
+  def get_projects_ns(resource_list):
+    for resource in resource_list["items"]:
+      # owner IAMPartialPolicy is expected to be in projects ns
+      if resource["kind"] == "IAMPartialPolicy" and resource["metadata"]["name"].endswith("owners-permissions"):
+        return resource["metadata"]["namespace"]
+    fail("unable to find project owner IAMPartialPolicy")
+
+  def get_mgmt_ns(resource_list):
+    for resource in resource_list["items"]:
+      # IAMServiceAccount is expected to be in management ns
+      if resource["kind"] == "IAMServiceAccount" and resource["metadata"]["name"].startswith("kcc-"):
+        return resource["metadata"]["namespace"]
+    fail("unable to find project KCC SA")
+
+  tenant_ns = get_tenant_ns(ctx.resource_list)
+  projects_ns = get_projects_ns(ctx.resource_list)
+  mgmt_ns = get_mgmt_ns(ctx.resource_list)
+
+  if tenant_ns == projects_ns:
+    fail("projects-namespace cannot be the same as tenant project")
+  if tenant_ns == mgmt_ns:
+    fail("management-namespace cannot be the same as tenant project")


### PR DESCRIPTION
Creation / adoption of a simplified KCC Namespaces taken from the https://cloud.google.com/anthos-config-management/docs/tutorials/project-namespace-blueprint.