### PR TITLE
updated references to sandbox-namespace/project

### DIFF
--- a/services/private-gke/gke/bigquerydataset.yaml
+++ b/services/private-gke/gke/bigquerydataset.yaml
@@ -20,7 +20,7 @@ metadata: # kpt-merge: ${NAMESPACE}/${CLUSTER_NAME}-bq-data
     cnrm.cloud.google.com/delete-contents-on-destroy: "true"
     cnrm.cloud.google.com/project-id: "sandbox-00000" # kpt-set: ${project-id}
   name: gkemetering
-  namespace: config-control # kpt-set: ${sandbox-namespace}
+  namespace: config-control # kpt-set: ${project-namespace}
 spec:
   defaultTableExpirationMs: 3600000
   description: "BigQuery Dataset Sample"

--- a/services/private-gke/gke/containercluster.yaml
+++ b/services/private-gke/gke/containercluster.yaml
@@ -16,10 +16,10 @@ apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerCluster
 metadata: # kpt-merge: ${NAMESPACE}/${CLUSTER_NAME}
   name: sandbox # kpt-set: ${cluster-name}
-  namespace: config-control # kpt-set: ${sandbox-namespace}
+  namespace: config-control # kpt-set: ${project-namespace}
   annotations:
     cnrm.cloud.google.com/remove-default-node-pool: "true"
-    cnrm.cloud.google.com/project-id: "sandbox-00000" # kpt-set: ${sandbox-project-id}
+    cnrm.cloud.google.com/project-id: "sandbox-00000" # kpt-set: ${project-id}
 spec:
   addonsConfig:
     configConnectorConfig:


### PR DESCRIPTION
Missed a reference kpt-setter pointing to `sandbox-namespace` and `sandbox-project-id`. Updated to be `project-namespace` and `project-id`.