### PR TITLE
added pubaccessprevention to pass guardrail #9

### DIFF
--- a/solutions/guardrails/configs/log-sinks/storage-sink.yaml
+++ b/solutions/guardrails/configs/log-sinks/storage-sink.yaml
@@ -45,6 +45,7 @@ spec:
   location: northamerica-northeast1
   storageClass: REGIONAL
   uniformBucketLevelAccess: true
+  publicAccessPrevention: true
 ---
 # PubSub Audit Log Viewer
 apiVersion: iam.cnrm.cloud.google.com/v1beta1


### PR DESCRIPTION
As the title says set `publicAccessPrevention: true` on the log sync bucket to prevent public access and to pass https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/guardrails-policies/09-network-security-services/template.yaml .