### PR TITLE
updated depends-on annotation

### DIFF
--- a/solutions/guardrails/configs/org-policies/org-policies.yaml
+++ b/solutions/guardrails/configs/org-policies/org-policies.yaml
@@ -31,7 +31,7 @@ metadata:
     guardrail: "true"
     guardrails-enforced: guardrail-05
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/gcp.resourceLocations"
   listPolicy:
@@ -60,7 +60,7 @@ metadata:
     guardrail: "true"
     guardrail-enforced: guardrail-09
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/compute.disableVpcExternalIpv6"
   booleanPolicy:
@@ -85,7 +85,7 @@ metadata:
   labels:
     guardrail: "false"
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/compute.requireShieldedVm"
   booleanPolicy:
@@ -110,7 +110,7 @@ metadata:
   labels:
     guardrail: "false"
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/compute.trustedImageProjects"
   listPolicy:
@@ -140,7 +140,7 @@ metadata:
     guardrail-enforced: guardrail-09
     guardrail: "true"
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/compute.vmExternalIpAccess"
   listPolicy:
@@ -166,7 +166,7 @@ metadata:
     guardrail: "true"
     guardrail-enforced: guardrail-02
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/iam.disableServiceAccountKeyCreation"
   booleanPolicy:
@@ -194,7 +194,7 @@ metadata:
     guardrail: "true"
     guardrail-enforced: guardrail-09
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/compute.restrictVpcPeering"
   listPolicy:
@@ -224,7 +224,7 @@ metadata:
     guardrail: "true"
     guardrail-enforced: guardrail-02
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/storage.uniformBucketLevelAccess"
   booleanPolicy:
@@ -252,7 +252,7 @@ metadata:
     guardrail: "true"
     guardrail-enforced: guardrail-06
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/compute.requireOsLogin"
   booleanPolicy:
@@ -282,7 +282,7 @@ metadata:
     guardrail: "true"
     guardrail-enforced: guardrail-06
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/compute.restrictLoadBalancerCreationForTypes"
   listPolicy:
@@ -315,7 +315,7 @@ metadata:
     guardrail: "true"
     guardrail-enforced: guardrail-02
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/essentialcontacts.allowedContactDomains"
   listPolicy:
@@ -348,7 +348,7 @@ metadata:
     guardrail: "true"
     guardrail-enforced: guardrail-06
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/iam.allowedPolicyMemberDomains"
   listPolicy:
@@ -378,7 +378,7 @@ metadata:
     guardrail: "true"
     guardrail-enforced: guardrails-02
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/compute.disableSerialPortAccess"
   booleanPolicy:
@@ -405,7 +405,7 @@ metadata:
   labels:
     guardrail: "false"
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/compute.vmCanIpForward"
   listPolicy:
@@ -434,7 +434,7 @@ metadata:
   labels:
     guardrail: "false"
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/compute.disableGuestAttributesAccess"
   booleanPolicy:
@@ -460,7 +460,7 @@ metadata:
   labels:
     guardrail: "false"
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/compute.disableNestedVirtualization"
   booleanPolicy:
@@ -486,7 +486,7 @@ metadata:
   labels:
     guardrail: "false"
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/compute.restrictXpnProjectLienRemoval"
   booleanPolicy:
@@ -511,7 +511,7 @@ metadata:
   labels:
     guardrail: "false"
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/sql.restrictPublicIp"
   booleanPolicy:
@@ -541,7 +541,7 @@ metadata:
   labels:
     guardrail: "false"
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${guardrails-project-id}-sa-policy-admin
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/guardrails-project-id-sa-policy-admin # kpt-set: iam.cnrm.cloud.google.com/namespaces/config-control/IAMPolicyMember/${management-project-id}-org-policyadmin
 spec:
   constraint: "constraints/storage.publicAccessPrevention"
   booleanPolicy:


### PR DESCRIPTION
Updated depends-on annotation for Org Policies. Was pointing to the wrong SA and ACM detects this as using an external reference which is not allowed. Fixed the reference and it now passes.