### PR TITLE
#33 - solutions sandbox-gke modify get-creds - ready to merge

### DIFF
--- a/solutions/sandbox-gke/README.md
+++ b/solutions/sandbox-gke/README.md
@@ -21,7 +21,7 @@ kubens config-control
 
 2. Fetch the package
 ```
-kpt pkg get git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/sandbox-gke sandbox-gke
+kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/sandbox-gke sandbox-gke
 ```
 
 3. Once we have done that we can start editing the `setters.yaml` file and populate the correct information. The values in the `setters` file will be used to populate the infrastructure YAML.


### PR DESCRIPTION
Running solutions/sandbox-gke
Going through the solutions/sandbox-gke first. kpt does not support https, also same change to the get-credentials

change
michael@cloudshell:~ (pubsec-declarative-toolkit-ns)$ gcloud anthos config controller get-credentials $CLUSTER --location $REGION
Fetching cluster endpoint and auth data.
kubeconfig entry generated for krmapihost-config-controller.

michael@cloudshell:~ (pubsec-declarative-toolkit-ns)$ kubens config-control
Context "gke_pubsec-declarative-toolkit-ns_us-east1_krmapihost-config-controller" modified.
Active namespace is "config-control".
michael@cloudshell:~ (pubsec-declarative-toolkit-ns)$ kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/sandbox-gke sandbox-gke
Error: Repository "https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit" requires authentication. kpt does not support this for the 'https' protocol. Please use the 'git' protocol instead.

add key
https://cloud.google.com/build/docs/access-github-from-build
michael@cloudshell:~ (pubsec-declarative-toolkit-ns)$ kpt pkg get [git@github.com](mailto:git@github.com):fmichaelobrien/pubsec-declarative-toolkit.git/solutions/sandbox-gke sandbox-gke