### PR TITLE
Updated Guardrails Setters File

### DIFF
--- a/solutions/guardrails/setters.yaml
+++ b/solutions/guardrails/setters.yaml
@@ -38,7 +38,7 @@ data:
   #
   management-project-id: config-controller-project
   management-namespace: config-control
-  management-project-number: "0000000000" # You can can this by running gcloud projects list --format="table(projectNumber)" --filter="management-project-id" <-- replace with management project id
+  management-project-number: "000000000000" # You can can this by running gcloud projects list --format="table(projectNumber)" --filter="management-project-id" <-- replace with management project id
   ####
   #
   # Org Policies


### PR DESCRIPTION
Bumped into issue with project number not being in quotes, this cause the folder to not generate correctly as it expects a string or null not an int. Also took the opportunity to move the project configuration setters to the top of the file for easier access and added some additional comments for clarity.