### PR TITLE
Changed git token to personal access token

### DIFF
--- a/cli/cmd/solution.go
+++ b/cli/cmd/solution.go
@@ -126,17 +126,19 @@ func (sl *solutionsList) getRemoteSolutions(url string, writeToCache bool, branc
 	reg := regexp.MustCompile(`^https://github.com/([a-zA-Z0-9-/]*)`)
 	res := reg.FindStringSubmatch(url)
 
-	if len(res) == 2 {
-		url = "https://raw.githubusercontent.com/" + res[1] + "/" + branch + "/" + subFolder + "/solutions.yaml"
-	} else {
-		return errors.New("malformed URL, unable to process")
-	}
-
 	// If the repo is private then a token can be passed in the URL to get access to the solutions file
 	gitToken := viper.GetString("git_token")
 
-	if  gitToken != "" {
-		url += "?token=" + gitToken
+	if len(res) == 2 {
+		url = "https://"
+
+		if  gitToken != "" {
+			url = url + gitToken + "@"
+		}
+
+		url = url + "raw.githubusercontent.com/" + res[1] + "/" + branch + "/" + subFolder + "/solutions.yaml"
+	} else {
+		return errors.New("malformed URL, unable to process")
 	}
 
 	if viper.GetBool("verbose") {

--- a/cli/docs/config.md
+++ b/cli/docs/config.md
@@ -10,7 +10,7 @@ It's a YAML formated file and contains the following configurable settings:
 | Setting        | Description | Default |
 | --- | --- | --- |
 | cache | This is the location of local cache directory where items like the config file, solutions file and otheres are stored. | ~/.arete |
-| git_token| If the GitHub repository that you are adding is private then you can still access the raw solutions file using a secure token. |
+| git_token| If the GitHub repository that you are adding is private then you can add your own Personal Access Token to the value in order to access the solutions.yaml file. This is not used to get the package. |
 | network | When creating a new config controller cluster you can override the VPC network that will be created | |
 | network.name   | The name of the VPC |  kcc-controller |
 | network.subnet | The name of the subnet | kcc-regional-subnet |

--- a/cli/docs/solutions.md
+++ b/cli/docs/solutions.md
@@ -2,6 +2,12 @@
 
 There are 2 aspects to way solutions are managed in arete. First there is a local `solutions.yaml` file that tracks all solutions that have been added to arete from either the global GitHub solutions library or by calling `arete solution get`.
 
+---
+*ALPHA NOTE:* Right now the GitHub repo is private and thusly you need to add your GitHub personal access token to the config file. See: [Config Doc](config.md)
+
+---
+
+
  ## Listing available solutions ##
 
  If you wish to see which solutions have been added and / or are available to arete, simple run the command `arete solution list`


### PR DESCRIPTION
This PR will change the way arete handles pulling a solutions.yaml file from a private repo including the alpha release of pubsec-declarative-toolkit. Instead of using an ephemeral git-token we will now use a users public access token. 

Closes #47