### PR TITLE
fixed indentation in limitegress traffic constraint

### DIFF
--- a/solutions/guardrails-policies/09-network-security-services/template.yaml
+++ b/solutions/guardrails-policies/09-network-security-services/template.yaml
@@ -28,7 +28,7 @@ spec:
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |-
-
+      
         package limitegresstraffic
 
         has_key(obj, field){


### PR DESCRIPTION
Small fix that addresses an indentation error in the Constraint's rego which caused the rego to convert to a single line instead of maintaining it's structure.