### PR TITLE
switched to https url for kpt pkg get commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,20 @@ The GCP PubSec Declarative Toolkit is a collection of declarative solutions to h
 
 ## Current Solutions
 
-**While this repo is private you will need to use `git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git` instead of the provided `https` url**
 
 When getting a package the `@` indicates what tag or branch you will be getting with the `kpt pkg get` command. The current version is set for `v0.0.2-alpha` and should be stable but you can use `main` if you want the latest changes as they come in.
 
 | Name | Description | Command | link |
 | --- | --- | --- | --- |
-| Guardrails | Base Infrastructure for 30 Day Guardrail Deployment | ```kpt pkg get git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/guardrails@v0.0.2-alpha guardrails``` | [link](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/guardrails) |
-| Guardrails Policy Bundle | Policy Bundle to help analyze compliance for Guardrails | ```kpt pkg get git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/guardrails-policies@v0.0.2-alpha guardrails-policies``` | [link](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/guardrails-policies) |
-| KCC Namespaces | This solution is a simple fork of the KCC Project Namespaces blueprint found [here](https://cloud.google.com/anthos-config-management/docs/tutorials/project-namespace-blueprint) | ```kpt pkg get git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/kcc-namespaces@v0.0.2-alpha kcc-namespaces``` | [link](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/kcc-namespaces) |
-| Sandbox GKE | Private GKE deployment | ```kpt pkg get git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/sandbox-gke@v0.0.2-alpha sandbox-gke``` | [link](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/sandbox-gke) |
-| Landing Zone | PBMM Landing Zone | ```kpt pkg get git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/landing-zone@v0.0.3-alpha landing-zone``` | [link](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/landing-zone) |
+| Guardrails | Base Infrastructure for 30 Day Guardrail Deployment | ```kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/guardrails@v0.0.2-alpha guardrails``` | [link](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/guardrails) |
+| Guardrails Policy Bundle | Policy Bundle to help analyze compliance for Guardrails | ```kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/guardrails-policies@v0.0.2-alpha guardrails-policies``` | [link](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/guardrails-policies) |
+| KCC Namespaces | This solution is a simple fork of the KCC Project Namespaces blueprint found [here](https://cloud.google.com/anthos-config-management/docs/tutorials/project-namespace-blueprint) | ```kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/kcc-namespaces@v0.0.2-alpha kcc-namespaces``` | [link](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/kcc-namespaces) |
+| Sandbox GKE | Private GKE deployment | ```kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/sandbox-gke@v0.0.2-alpha sandbox-gke``` | [link](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/sandbox-gke) |
+| Landing Zone | PBMM Landing Zone | ```kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/landing-zone@v0.0.3-alpha landing-zone``` | [link](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/landing-zone) |
 
 ## Quickstart
 
-<!-- [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git&cloudshell_workspace=.&cloudshell_tutorial=docs/cloudshell-tutorial.md) -->
+<!-- [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git&cloudshell_workspace=.&cloudshell_tutorial=docs/cloudshell-tutorial.md) -->
 
 In order to deploy the solutions we will need to activate a config-controller instance which we will then deploy a solution or solutions to it.
 

--- a/services/bastion-host/README.md
+++ b/services/bastion-host/README.md
@@ -14,7 +14,7 @@ If you wish you can edit the os-config.yaml file to add / remove any software yo
 ## Usage
 
 ### **Fetch the package**
-`kpt pkg get git@github.com:GoogleCloudPlatform/gcp-pbmm-sandbox.git/services/bastion-host@main bastion-host`
+`kpt pkg get https://github.com/GoogleCloudPlatform/gcp-pbmm-sandbox.git/services/bastion-host@main bastion-host`
 
 Details: https://kpt.dev/reference/cli/pkg/get/
 

--- a/services/private-sql/README.MD
+++ b/services/private-sql/README.MD
@@ -50,7 +50,7 @@ You can easily change any of the defaults that this sevice uses by modifying the
 | Charset / Collation | UTF8 / en_US.UTF8 | sql.yaml(46/47) |
 
 ### **Fetch the package**
-`kpt pkg get git@github.com:GoogleCloudPlatform/gcp-pbmm-sandbox.git/services/private-sql@main private-sql`
+`kpt pkg get https://github.com/GoogleCloudPlatform/gcp-pbmm-sandbox.git/services/private-sql@main private-sql`
 Details: https://kpt.dev/reference/cli/pkg/get/
 
 ### **View package content**

--- a/solutions/guardrails/README.md
+++ b/solutions/guardrails/README.md
@@ -48,7 +48,7 @@ This packge contains the minimal set of infrastructure needed to help provision 
 1. Fetch the `guardrails` package by running the `kpt pkg get` command.
 
 ```
-kpt pkg get git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/guardrails@v0.0.2-alpha guardrails
+kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/guardrails@v0.0.2-alpha guardrails
 ```
 
 This will download the package containing the configuration files for the Guardrails deployment.

--- a/solutions/landing-zone/README.md
+++ b/solutions/landing-zone/README.md
@@ -116,7 +116,7 @@ To deploy this Landing Zone you will first need to create a Bootstrap project wi
     
 2. Fetch the package
 
-    `kpt pkg get git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/landing-zone landing-zone`
+    `kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/landing-zone landing-zone`
 
     Details: https://kpt.dev/reference/cli/pkg/get/
 

--- a/solutions/solutions.yaml
+++ b/solutions/solutions.yaml
@@ -16,20 +16,20 @@ solutions:
   - solution: guardrails
     description: |
       Implementation of the GC Cloud Guardrails Checks. More Info: https://github.com/canada-ca/cloud-guardrails-gcp
-    url: git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/guardrails@main
+    url: https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/guardrails@main
   - solution: guardrails-policy-bundle
     description: |
       Policy Bundle to help analyze compliance for Guardrails
-    url: git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/guardrails-policies@main
+    url: https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/guardrails-policies@main
   - solution: kcc-namespaces
     description: |
       Simplified declarative multi-tenancy with project namespaces taken from: https://cloud.google.com/anthos-config-management/docs/tutorials/project-namespace-blueprint
-    url: git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/kcc-namespaces@main
+    url: https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/kcc-namespaces@main
   - solution: sandbox-gke
     description: |
       A private GKE cluster with so many bells and whistles!
-    url: git@github.com:GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/sandbox-gke@main
+    url: https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/sandbox-gke@main
   - solution: landing-zone
     description: |
       This is a reimplementation of pbmm-on-gcp-onboarding Landing Zone using KRM.
-    url: git@github.com:GoogleCloudPlatform/gcp-pbmm-sandbox.git/solutions/landing-zone@main
+    url: https://github.com/GoogleCloudPlatform/gcp-pbmm-sandbox.git/solutions/landing-zone@main


### PR DESCRIPTION
Switch `kpt pkg get` commands to use https instead of `git:` before going public.