### PR TITLE
Added services to enable, depencies to check in solution spec

### DIFF
--- a/cli/docs/solution.md
+++ b/cli/docs/solution.md
@@ -23,6 +23,13 @@ deploy:                                                         # deployment pip
             resource:                                                 # add role binding to a resource
               level: "organization|project"                           # bindings are added at either the organization or project level
               id: "123abc"                                            # organization ID or Project ID
+        services:                                               # enable apis on the project, normally used to enable apis outside the project the solution is being deployed into
+          - service: "api.googleapis.com"                       # api to be enabled
+            project: "project ID"                               # project ID that the API should be enabled on
+        depends:                                                # depends uses the asset inventory, search-all-resources gcloud command
+          - asset-type: "compute.googleapis.com/Networks"       # see https://cloud.google.com/asset-inventory/docs/supported-asset-types#searchable_asset_types
+            scope: "projects/prod_id"                           # projects/project_id or organizations/org_id or folders/folder_id
+            name: "my-vpc"                                      # the name of the asset
       kubeContext:                                              # Kube Context configuration
         clusterName: "cluster name"                             # the name of the GKE cluster in which KCC is installed and setup on
         region: "gcp region"                                    # the region the GKE cluster is in. Set if the cluster is regional else use zone

--- a/cli/pkg/api/solution/v1/types.go
+++ b/cli/pkg/api/solution/v1/types.go
@@ -50,10 +50,23 @@ func (s *Spec) IsEmpty() bool {
 type Requires struct {
 	UseConfigConnectorSA string `yaml:"useConfigConnectorSA,omitempty"`
 	Iam                  []Iam  `yaml:"iam,omitempty"`
+	Services						 []Services `yaml:"services,omitempty"`
+	Depends							 []Depends	`yaml:"depends,omitempty"`
 }
 
 func (r *Requires) IsEmpty() bool {
 	return len(r.UseConfigConnectorSA) == 0 && len(r.Iam) == 0
+}
+
+type Services struct {
+	Service string `yaml:"service,omitempty"`
+	Project string `yaml:"project,omitempty"`
+}
+
+type Depends struct {
+	AssetType string `yaml:"asset-type,omitempty"`
+	Scope			string `yaml:"scope,omitempty"`
+	Name			string `yaml:"name,omitempty"`
 }
 
 type Deploy struct {


### PR DESCRIPTION
Updated solution.yaml spec to include the ability to enable Google Cloud api services in projects (usually in a different project than the target for the solution) and dependencies that must be created first before the solution can be deployed.

Example of services would something like sqladmin.googleapis.com that needs to be enabled on the KCC host project in order for it be able to setup Cloud SQL on the target / tenant project.

The dependencies check uses the Google Cloud Asset Inventory gcloud command, thanks @cartyc for the idea!