### PR TITLE
Changed external IP and location resources to allowAll: false

### DIFF
--- a/solutions/guardrails/configs/org-policies/org-policies.yaml
+++ b/solutions/guardrails/configs/org-policies/org-policies.yaml
@@ -36,7 +36,7 @@ spec:
   constraint: "constraints/gcp.resourceLocations"
   listPolicy:
     allow:
-      all: true
+      all: false
       values: # kpt-set: ${allowed-regions}
         - northamerica-northeast1
         - northamerica-northeast2
@@ -145,7 +145,7 @@ spec:
   constraint: "constraints/compute.vmExternalIpAccess"
   listPolicy:
     allow:
-      all: true
+      all: false
       values:
   organizationRef:
     # Replace "${ORG_ID?}" with the numeric ID for your organization


### PR DESCRIPTION
Fixed misconfigured org policies. Turned settings from allow all `true` to allow all `false`.

This will impact the `resourcelocation` and `vmexternalipaccess` policies. Default will now be to deny all for non-compliant resources.