### PR TITLE
added krmignore file and added cicd-examples to it

### DIFF
--- a/solutions/landing-zone/.krmignore
+++ b/solutions/landing-zone/.krmignore
@@ -1,0 +1,1 @@
+cicd-examples/


### PR DESCRIPTION
Added `.krmignore` file to landing zone solution to ignore the cicd-examples directory. KRM Ignore files work similarly to `.gitignore` files and will tell `kpt` to ignore files or directories included in it.

This fixes an issue where `kpt` tries to run `render` on the yaml in the CICD examples directory but fails due to the lack of a `apiVersion` key. By ommiting the directory the folder is ommited and `kpt` will ignore it during the `render` phase.