### PR TITLE
#103 - workaround for missing cluster policy CRDs

### DIFF
--- a/solutions/landing-zone/.krmignore
+++ b/solutions/landing-zone/.krmignore
@@ -1,1 +1,3 @@
 cicd-examples/
+environments/common/guardrails-policies
+environments/common/general-policies/naming-rules


### PR DESCRIPTION
Let me just retest this change on another organization
I tested it on gcp.zone, retesting over friday on nuage-cloud.org that had the same issue