### PR TITLE
Update allowed Load Balancer and external VM IP Policies

### DIFF
--- a/solutions/landing-zone/environments/common/policies/org-policies.yaml
+++ b/solutions/landing-zone/environments/common/policies/org-policies.yaml
@@ -134,9 +134,8 @@ metadata:
 spec:
   constraint: "constraints/compute.vmExternalIpAccess"
   listPolicy:
-    allow:
-      all: false
-      values:
+    deny:
+      all: true
   organizationRef:
     # Replace "${ORG_ID?}" with the numeric ID for your organization
     external: "0000000000" # kpt-set: ${org-id}          
@@ -270,7 +269,6 @@ spec:
     allow:
       all: false # set to false to disable
       values: # kpt-set: ${allowed-loadbalancers}
-        - INTERNAL
         - INTERNAL_TCP_UDP
         - INTERNAL_HTTP_HTTPS
   organizationRef:


### PR DESCRIPTION
Removed unsupported value for loadbalancers and set externalip to deny all true instead of allow all false.

Deployed lz into a new cluster and both policies (`restrict-vm-external-access`, and `restrict-loadbalancer-creation-types`) failed to provision. This update fixes the issue and policies should now come up with no issues.