### PR TITLE
added gh action to validate landing zone solution

### DIFF
--- a/.github/workflows/landing-zone-validation.yaml
+++ b/.github/workflows/landing-zone-validation.yaml
@@ -1,0 +1,33 @@
+name: landing-zone-validation
+on:
+  push:
+    paths:
+      - solutions/landing-zone/**
+jobs:
+  solutions-render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1  
+      - name: kpt fn render landing-zone
+        run: |
+          docker run -v $PWD:/app -v /var/run/docker.sock:/var/run/docker.sock gcr.io/kpt-dev/kpt:v1.0.0-beta.19 fn render /app/solutions/landing-zone
+      - name: 'Upload Solution Artifact'
+        uses: actions/upload-artifact@v3
+        with:
+          name: lz-render
+          path: ./solutions
+          retention-days: 1
+  solutions-validate:
+    runs-on: ubuntu-latest
+    needs: solutions-render
+    steps:
+      - name: Download Solutions
+        uses: actions/download-artifact@v3
+        with:
+          name: lz-render
+      - name: dir check
+        run: pwd && ls
+      - name: nomos vet landing-zone
+        run: |
+          docker run -v $PWD:/landing-zone gcr.io/config-management-release/nomos:stable nomos vet --no-api-server-check --source-format unstructured --path /landing-zone/landing-zone/environments


### PR DESCRIPTION
This PR will add a github action to test and validate the Landing Zone Solution.

The Action will run two steps, the first will run `kpt fn render` to test the render process and populate the LZ with the default values. The second step will run [nomos vet](https://cloud.google.com/anthos-config-management/docs/how-to/nomos-command) on the newly render landing zone to check for any errors in the solution.