### PR TITLE
#111 - fix kpt steps for in/out lz dir

### DIFF
--- a/solutions/landing-zone/README.md
+++ b/solutions/landing-zone/README.md
@@ -177,7 +177,9 @@ To deploy this Landing Zone you will first need to create a Bootstrap project wi
     a. kpt
     
     ```
+    cd landing-zone
     kpt fn render
+    cd ..
     kpt live init landing-zone --namespace config-control
     kpt live apply landing-zone --reconcile-timeout=2m --output=table
     ```

--- a/solutions/landing-zone/README.md
+++ b/solutions/landing-zone/README.md
@@ -177,9 +177,7 @@ To deploy this Landing Zone you will first need to create a Bootstrap project wi
     a. kpt
     
     ```
-    cd landing-zone
-    kpt fn render
-    cd ..
+    kpt fn render landing-zone
     kpt live init landing-zone --namespace config-control
     kpt live apply landing-zone --reconcile-timeout=2m --output=table
     ```


### PR DESCRIPTION
see https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/issues/111#issuecomment-1242747264

before
```
michael@cloudshell:~/github/GoogleCloudPlatform/20220909-103/landing-zone (lz-20220910-oldev)$ cd landing-zone/
-bash: cd: landing-zone/: No such file or directory
```

after
```
michael@cloudshell:~/github/GoogleCloudPlatform/20220909-103 (lz-20220910-oldev)$ cd landing-zone/
michael@cloudshell:~/github/GoogleCloudPlatform/20220909-103/landing-zone (lz-20220910-oldev)$ kpt fn render
Package "landing-zone/environments/common/guardrails-policies":
Successfully executed 9 function(s) in 5 package(s).
michael@cloudshell:~/github/GoogleCloudPlatform/20220909-103/landing-zone (lz-20220910-oldev)$ cd ..
michael@cloudshell:~/github/GoogleCloudPlatform/20220909-103 (lz-20220910-oldev)$ kpt live init landing-zone --namespace config-control
initializing Kptfile inventory info (namespace: config-control)...failed
michael@cloudshell:~/github/GoogleCloudPlatform/20220909-103 (lz-20220910-oldev)$ kpt live apply landing-zone --reconcile-timeout=2m
installing inventory ResourceGroup CRD.
```