### PR TITLE
fixed typo in file name

### DIFF
--- a/solutions/landing-zone/environments/common/guardrails-policies/05-data-location/constraint.yaml
+++ b/solutions/landing-zone/environments/common/guardrails-policies/05-data-location/constraint.yaml
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: DataLocation
+metadata: # kpt-merge: /datalocation
+  name: datalocation
+spec:
+  match:
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["*"]
+  parameters:
+    locations:
+      - "northamerica-northeast1"
+      - "northamerica-northeast2"
+      - "global"
+    allowedServices:
+      - ""


### PR DESCRIPTION
This PR fixes a typo in the constraint.yaml file name in the datalocation guardrail.

File name was constaint.yaml instead of constraint.yaml.