### PR TITLE
Update to LZ deployment Docs

### DIFF
--- a/solutions/landing-zone/README.md
+++ b/solutions/landing-zone/README.md
@@ -181,6 +181,8 @@ To deploy this Landing Zone you will first need to create a Bootstrap project wi
 
     ### kpt
     
+    Before deploying with `kpt` you will need to add `constraints.yaml` to the `.krmignore` file. This is due to needing to have the `constraintstemplate` resources deployed into the instance before the policy `constraint` can be deployed. Once the `constrainttemplates` have been deployed you can remove `constraints.yaml` from the `.krmignore` file and redeploy. This is not needed with either gitops deployment options.
+
     ```
     kpt fn render landing-zone
     kpt live init landing-zone --namespace config-control

--- a/solutions/landing-zone/README.md
+++ b/solutions/landing-zone/README.md
@@ -467,7 +467,7 @@ To deploy this Landing Zone you will first need to create a Bootstrap project wi
 
       Once the resources have been deleted you can delete the config controller instance .
       
-      If you have forgotten tha name of the instance you can run `gcloud config controller list` to reveal the instances in your project.
+      If you have forgotten the name of the instance you can run `gcloud config controller list` to reveal the instances in your project.
 
       ```
       gcloud anthos config controller instance-name --location instance-region

--- a/solutions/landing-zone/README.md
+++ b/solutions/landing-zone/README.md
@@ -427,6 +427,32 @@ To deploy this Landing Zone you will first need to create a Bootstrap project wi
 
       #### Clean Up
 
+      Follow the below steps to delete the provisioned infrastructure and Config Controller instances.
+
+      If you want the deployed resources to live on and just destroy the Config Controller instance you can do so by running `gcloud anthos config controller instance-name --location instance-region`. This will remove the config controller instances but leave the resources it deployed untouched.
+
+      To reacquire the resources you will need to redeploy a new instance and deploy the same configs to it. Config Controller should reattach to the previously deployed instances and start managing them again.
+
+      #### kpt
+
+      First run either
+      ```
+      kpt live destroy
+      ```
+
+      or
+
+      ```
+      kubectl delete gcp --all
+      ```
+
+      Finally delete the Config Controller instance
+
+      ```
+      gcloud anthos config controller instance-name --location instance-region
+      ```
+
+      #### OCI
       First delete the Rootsync deployment. This will prevent the resources from self-healing.
 
       ```

--- a/solutions/landing-zone/README.md
+++ b/solutions/landing-zone/README.md
@@ -100,6 +100,7 @@ To deploy this Landing Zone you will first need to create a Bootstrap project wi
     gcloud alpha logging settings update --organization=$ORG_ID --storage-location=$REGION
     ```
 
+
 1. Deploy Bootstrap
 
     This bootstrap assume you have a [Config Controller](https://cloud.google.com/anthos-config-management/docs/concepts/config-controller-overview) instance provisioned already. If you do not you can follow either the [quickstart](https://cloud.google.com/anthos-config-management/docs/concepts/config-controller-overview) guide or the [detailed install guide](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/docs/advanced-install.md) for advanced users (this is recommended for experienced users).
@@ -126,6 +127,10 @@ To deploy this Landing Zone you will first need to create a Bootstrap project wi
     gcloud organizations add-iam-policy-binding "${ORG_ID}" --member "serviceAccount:${SA_EMAIL}" --role roles/logging.admin
     ```
     
+    **Note**: You will also need to give the Service Account ($SA_EMAIL) the Billing Account User role on your billing account in order to allow it to associate billing IDs to the Projects that will be created. You can do that by following the steps in this [guide](https://cloud.google.com/billing/docs/how-to/billing-access#update-cloud-billing-permissions). If this is not granted projects will not be able to be provisioned.
+
+    Deploying without Billing Account User role is possible but will require a user who does to manually add the billing account to the project. To do this you will need to remove the Billing Section of any deployed project (projects can be found in the following directories `common/projects`,`nonprod/projects`, `prod/projects`). Once the project is created the user with the Billing User will be able to add the billing id to the generated projects in the [manage billing page](https://console.cloud.google.com/billing).
+
 2. Fetch the package
 
     `kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/landing-zone landing-zone`
@@ -188,8 +193,6 @@ To deploy this Landing Zone you will first need to create a Bootstrap project wi
     kpt live init landing-zone --namespace config-control
     kpt live apply landing-zone --reconcile-timeout=2m --output=table
     ```
-
-    **Note**: Deploying without billing use permissions is possible but will require a user to manually add the billing account to the project. To do this you will need to remove the Billing Section of any deployed project (projects can be found in the following directories `common/projects`,`nonprod/projects`, `prod/projects`).
 
     The section looks like the following and can either be commented out or deleted.
     ```

--- a/solutions/landing-zone/README.md
+++ b/solutions/landing-zone/README.md
@@ -102,7 +102,7 @@ To deploy this Landing Zone you will first need to create a Bootstrap project wi
 
 1. Deploy Bootstrap
 
-    This bootstrap assume you have a [Config Controller](https://cloud.google.com/anthos-config-management/docs/concepts/config-controller-overview) instance provisioned already. If you do not you can follow either the [quickstart]https://cloud.google.com/anthos-config-management/docs/concepts/config-controller-overview) guide or the [detailed install guide](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/docs/advanced-install.md) for advanced users.
+    This bootstrap assume you have a [Config Controller](https://cloud.google.com/anthos-config-management/docs/concepts/config-controller-overview) instance provisioned already. If you do not you can follow either the [quickstart](https://cloud.google.com/anthos-config-management/docs/concepts/config-controller-overview) guide or the [detailed install guide](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/docs/advanced-install.md) for advanced users.
     
 
     This Solution will require the Config Controller instance to have the following permissions.

--- a/solutions/landing-zone/README.md
+++ b/solutions/landing-zone/README.md
@@ -182,7 +182,7 @@ To deploy this Landing Zone you will first need to create a Bootstrap project wi
     ### kpt
     
     ```
-    kpt fn render
+    kpt fn render landing-zone
     kpt live init landing-zone --namespace config-control
     kpt live apply landing-zone --reconcile-timeout=2m --output=table
     ```
@@ -366,7 +366,7 @@ To deploy this Landing Zone you will first need to create a Bootstrap project wi
       At this point we'll want to update our `setters.yaml` with the appropriate values and render the solution configurations using `kpt`.
 
       ```
-      kpt fn render
+      kpt fn render landing-zone
       kpt live init landing-zone --namespace config-control
       kpt live apply landing-zone --reconcile-timeout=2m --output=table
       ``` 


### PR DESCRIPTION
Updating documentation on LZ deployment. 

This PR is aimed at improving the documentation around deploying with `kpt` and GitOps options. I am hoping to make things clearer as to what the different options do and when to use them.

Leaving this as a draft to collect more input and to test the new instructions around using OCI.