### PR TITLE
added missing namespace

### DIFF
--- a/solutions/landing-zone/environments/common/audit/audit-bucket.yaml
+++ b/solutions/landing-zone/environments/common/audit/audit-bucket.yaml
@@ -39,6 +39,7 @@ metadata:
     resource-group: common
   # StorageBucket names must be globally unique. Replace ${PROJECT_ID?} with your project ID.
   name: audit-sink-${project-id} # kpt-set: audit-${audit-prj-id}
+  namespace: common
 spec:
   lifecycleRule:
     - action:


### PR DESCRIPTION
Added missing namespace on audit bucket storage. This will fix the issue of the audit bucket being provisioned in the `default` namespace instead of the expected `config-control` namespace.