### PR TITLE
replaced IAM Policy with IAMPartialPolicy

### DIFF
--- a/solutions/landing-zone/environments/common/audit/audit-bucket.yaml
+++ b/solutions/landing-zone/environments/common/audit/audit-bucket.yaml
@@ -65,25 +65,18 @@ spec:
 ---
 # Audit Bucket Viewer
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata: # kpt-merge: config-control/bq-audit-data-viewer
   name: audit-sink-writer
   namespace: config-control # kpt-set: ${management-namespace}
-  annotations:
-    config.kubernetes.io/apply-time-mutation: |
-      - sourceRef:
-          apiVersion: v1beta1
-          group: logging.cnrm.cloud.google.com
-          kind: LoggingLogSink
-          name: audit-bucket-sink
-          namespace: config-control
-        sourcePath: $.status.writerIdentity
-        targetPath: $.spec.member
-        token: ${logging-writerIdentity}
 spec:
-  member: ${logging-writerIdentity}
   resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    apiVersion: storage.cnrm.cloud.google.com/v1beta1
     kind: StorageBucket
     name: audit-sink-${project-id} # kpt-set: audit-${audit-prj-id}
-  role: roles/storage.objectCreator
+  bindings:
+    - role: roles/storage.objectCreator
+      members:
+        - memberFrom: 
+            logSinkRef: 
+              name: audit-bucket-sink

--- a/solutions/landing-zone/environments/common/audit/log-bucket.yaml
+++ b/solutions/landing-zone/environments/common/audit/log-bucket.yaml
@@ -65,26 +65,18 @@ spec:
 ---
 # Log Bucket Viewer
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata: # kpt-merge: config-control/bq-audit-data-viewer
   name: log-sink-writer
   namespace: config-control # kpt-set: ${management-namespace}
-  annotations:
-    config.kubernetes.io/apply-time-mutation: |
-      - sourceRef:
-          apiVersion: v1beta1
-          group: logging.cnrm.cloud.google.com
-          kind: LoggingLogSink
-          name: logs-bucket-sink
-          namespace: config-control
-        sourcePath: $.status.writerIdentity
-        targetPath: $.spec.member
-        token: ${logging-writerIdentity}
 spec:
-  member: ${logging-writerIdentity}
   resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    apiVersion: storage.cnrm.cloud.google.com/v1beta1
     kind: StorageBucket
     name: log-bucket # kpt-set: log-bucket-${audit-prj-id}
-  role: roles/storage.objectCreator
-  
+  bindings:
+    - role: roles/storage.objectCreator
+      members:
+        - memberFrom: 
+            logSinkRef: 
+              name: logs-bucket-sink


### PR DESCRIPTION
This pr replaces the existing `IAMPolicy` which relied on the `kpt` `apply-time-mutation` annotation to inject the `LoggingLogSink` writer identity value with the newer `IAMPartialPolicy`. 

`IAMPartialPolicy` allows us to reference the `LoggingLogSink` object directly and apply the required permissions to the underlying writer Identity without needing to know what it is beforehand.

IAMPartialPolicy docs --> https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy#supported_resources