### PR TITLE
Guardrails logsink iam

### DIFF
--- a/.github/workflows/guardrails-validation.yaml
+++ b/.github/workflows/guardrails-validation.yaml
@@ -30,4 +30,4 @@ jobs:
         run: pwd && ls
       - name: nomos vet guardrails
         run: |
-          docker run -v $PWD:/guardrails gcr.io/config-management-release/nomos:stable nomos vet --no-api-server-check --source-format unstructured --path /guardrails/guardrails/environments
+          docker run -v $PWD:/guardrails gcr.io/config-management-release/nomos:stable nomos vet --no-api-server-check --source-format unstructured --path /guardrails/configs

--- a/.github/workflows/guardrails-validation.yaml
+++ b/.github/workflows/guardrails-validation.yaml
@@ -1,0 +1,33 @@
+name: guardrails-validation
+on:
+  push:
+    paths:
+      - solutions/guardrails/**
+jobs:
+  solutions-render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1  
+      - name: kpt fn render guardrails
+        run: |
+          docker run -v $PWD:/app -v /var/run/docker.sock:/var/run/docker.sock gcr.io/kpt-dev/kpt:v1.0.0-beta.19 fn render /app/solutions/guardrails
+      - name: 'Upload Solution Artifact'
+        uses: actions/upload-artifact@v3
+        with:
+          name: lz-render
+          path: ./solutions
+          retention-days: 1
+  solutions-validate:
+    runs-on: ubuntu-latest
+    needs: solutions-render
+    steps:
+      - name: Download Solutions
+        uses: actions/download-artifact@v3
+        with:
+          name: lz-render
+      - name: dir check
+        run: pwd && ls
+      - name: nomos vet guardrails
+        run: |
+          docker run -v $PWD:/guardrails gcr.io/config-management-release/nomos:stable nomos vet --no-api-server-check --source-format unstructured --path /guardrails/guardrails/environments

--- a/solutions/guardrails/Kptfile
+++ b/solutions/guardrails/Kptfile
@@ -9,6 +9,7 @@ pipeline:
     - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml
     - image: gcr.io/kpt-fn/enable-gcp-services:v0.1.0
+    - image: 'gcr.io/kpt-fn/generate-folders:v0.1.1'
   validators:
     - image: gcr.io/kpt-fn/kubeval:v0.2
       configMap:

--- a/solutions/guardrails/configs/log-sinks/bigquery-sink.yaml
+++ b/solutions/guardrails/configs/log-sinks/bigquery-sink.yaml
@@ -51,13 +51,15 @@ kind: IAMPartialPolicy
 metadata: 
   name: bq-sink-writer
   namespace: config-control # kpt-set: ${management-namespace}
+  annotations:
+    config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/config-control/LoggingLogSink/bigquery-logsink # kpt-set: logging.cnrm.cloud.google.com/namespaces/${management-namespace}/LoggingLogSink/bigquery-logsink
 spec:
   resourceRef:
-    apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
-    kind: BigQueryDataset
-    name: bigquerylogginglogsink
+    kind: Project
+    name: guardrails-project-id # kpt-set: ${guardrails-project-id}
   bindings:
-    role: roles/bigquery.admin
-    members:
-      - memberFrom: 
-          logSinkRef: bigquery-logsink
+    - role: roles/bigquery.dataOwner
+      members:
+        - memberFrom: 
+            logSinkRef:
+              name: bigquery-logsink

--- a/solutions/guardrails/configs/log-sinks/bigquery-sink.yaml
+++ b/solutions/guardrails/configs/log-sinks/bigquery-sink.yaml
@@ -15,7 +15,7 @@
 # BigQuery Log Sink
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
-metadata: # kpt-merge: guardrails/bigquery-logsink
+metadata:
   name: bigquery-logsink
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
@@ -34,7 +34,7 @@ spec:
 # Big Query Instance
 apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
 kind: BigQueryDataset
-metadata: # kpt-merge: guardrails/bigquerylogginglogsink
+metadata:
   name: bigquerylogginglogsink
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
@@ -47,25 +47,17 @@ spec:
 ---
 # BigQuery Audit Log Viewer
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
-metadata: # kpt-merge: config-control/bq-audit-data-viewer
+kind: IAMPartialPolicy
+metadata: 
   name: bq-sink-writer
   namespace: config-control # kpt-set: ${management-namespace}
-  annotations:
-    config.kubernetes.io/apply-time-mutation: |
-      - sourceRef:
-          apiVersion: v1beta1
-          group: logging.cnrm.cloud.google.com
-          kind: LoggingLogSink
-          name: bigquery-logsink
-          namespace: config-control
-        sourcePath: $.status.writerIdentity
-        targetPath: $.spec.member
-        token: ${logging-writerIdentity}
 spec:
-  member: ${logging-writerIdentity}
   resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Project
-    external: project-id # kpt-set: ${guardrails-project-id}
-  role: roles/bigquery.admin
+    apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+    kind: BigQueryDataset
+    name: bigquerylogginglogsink
+  bindings:
+    role: roles/bigquery.admin
+    members:
+      - memberFrom: 
+          logSinkRef: bigquery-logsink

--- a/solutions/guardrails/configs/log-sinks/pubsub-sink.yaml
+++ b/solutions/guardrails/configs/log-sinks/pubsub-sink.yaml
@@ -14,7 +14,7 @@
 # PubSub Log Sink
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
-metadata: # kpt-merge: guardrails/pubsub-logsink
+metadata: 
   name: pubsub-logsink
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
@@ -32,7 +32,7 @@ spec:
 # PubSub Instance
 apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
 kind: PubSubTopic
-metadata: # kpt-merge: guardrails/logginglogsink-org
+metadata:
   name: logginglogsink-org
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
@@ -41,25 +41,17 @@ metadata: # kpt-merge: guardrails/logginglogsink-org
 ---
 # PubSub Audit Log Viewer
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
-metadata: # kpt-merge: config-control/bq-audit-data-viewer
+kind: IAMPartialPolicy
+metadata:
   name: pubsub-sink-writer
   namespace: config-control # kpt-set: ${management-namespace}
-  annotations:
-    config.kubernetes.io/apply-time-mutation: |
-      - sourceRef:
-          apiVersion: v1beta1
-          group: logging.cnrm.cloud.google.com
-          kind: LoggingLogSink
-          name: pubsub-logsink
-          namespace: config-control
-        sourcePath: $.status.writerIdentity
-        targetPath: $.spec.member
-        token: ${logging-writerIdentity}
 spec:
-  member: ${logging-writerIdentity}
   resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Project
-    external: project-id # kpt-set: ${guardrails-project-id}
-  role: roles/pubsub.admin
+    apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
+    kind: PubSubTopic
+    name: logginglogsink-org
+  bindings:
+    role: roles/pubsub.editor
+    members:
+      - memberFrom: 
+          logSinkRef: bigquery-logsink

--- a/solutions/guardrails/configs/log-sinks/pubsub-sink.yaml
+++ b/solutions/guardrails/configs/log-sinks/pubsub-sink.yaml
@@ -45,13 +45,16 @@ kind: IAMPartialPolicy
 metadata:
   name: pubsub-sink-writer
   namespace: config-control # kpt-set: ${management-namespace}
+  annotations:
+    config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/config-control/LoggingLogSink/pubsub-logsink # kpt-set: logging.cnrm.cloud.google.com/namespaces/${management-namespace}/LoggingLogSink/pubsub-logsink
 spec:
   resourceRef:
     apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
     kind: PubSubTopic
     name: logginglogsink-org
   bindings:
-    role: roles/pubsub.editor
-    members:
-      - memberFrom: 
-          logSinkRef: bigquery-logsink
+    - role: roles/pubsub.editor
+      members:
+        - memberFrom: 
+            logSinkRef: 
+              name: pubsub-logsink

--- a/solutions/guardrails/configs/log-sinks/storage-sink.yaml
+++ b/solutions/guardrails/configs/log-sinks/storage-sink.yaml
@@ -49,25 +49,17 @@ spec:
 ---
 # PubSub Audit Log Viewer
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
-metadata:
+kind: IAMPartialPolicy
+metadata: 
   name: storage-sink-writer
   namespace: config-control # kpt-set: ${management-namespace}
-  annotations:
-    config.kubernetes.io/apply-time-mutation: |
-      - sourceRef:
-          apiVersion: v1beta1
-          group: logging.cnrm.cloud.google.com
-          kind: LoggingLogSink
-          name: storage-logsink
-          namespace: config-control
-        sourcePath: $.status.writerIdentity
-        targetPath: $.spec.member
-        token: ${logging-writerIdentity}
 spec:
-  member: ${logging-writerIdentity}
   resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Project
-    external: project-id # kpt-set: ${guardrails-project-id}
-  role: roles/storage.admin
+    apiVersion: storage.cnrm.cloud.google.com/v1beta1
+    kind: StorageBucket
+    name: 0000000000-logginglogsink-goc # kpt-set: ${org-id}-logginglogsink-${department-code}
+  bindings:
+    role: roles/storage.objectCreator
+    members:
+      - memberFrom: 
+          logSinkRef: storage-logsink

--- a/solutions/guardrails/configs/log-sinks/storage-sink.yaml
+++ b/solutions/guardrails/configs/log-sinks/storage-sink.yaml
@@ -53,13 +53,16 @@ kind: IAMPartialPolicy
 metadata: 
   name: storage-sink-writer
   namespace: config-control # kpt-set: ${management-namespace}
+  annotations:
+    config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/config-control/LoggingLogSink/storage-logsink # kpt-set: logging.cnrm.cloud.google.com/namespaces/${management-namespace}/LoggingLogSink/storage-logsink
 spec:
   resourceRef:
     apiVersion: storage.cnrm.cloud.google.com/v1beta1
     kind: StorageBucket
     name: 0000000000-logginglogsink-goc # kpt-set: ${org-id}-logginglogsink-${department-code}
   bindings:
-    role: roles/storage.objectCreator
-    members:
-      - memberFrom: 
-          logSinkRef: storage-logsink
+    - role: roles/storage.objectCreator
+      members:
+        - memberFrom: 
+            logSinkRef: 
+              name: storage-logsink

--- a/solutions/guardrails/configs/org-policies/org-policies.yaml
+++ b/solutions/guardrails/configs/org-policies/org-policies.yaml
@@ -144,9 +144,8 @@ metadata:
 spec:
   constraint: "constraints/compute.vmExternalIpAccess"
   listPolicy:
-    allow:
-      all: false
-      values:
+    deny:
+      all: true
   organizationRef:
     # Replace "${ORG_ID?}" with the numeric ID for your organization
     external: "0000000000" # kpt-set: ${org-id}          


### PR DESCRIPTION
This PR updates the logginglogsink objects to use IAMPartialPolicy instead of relying on the `apply-time-mutation` feature.

Additionally adds a github action for validation of the guardrails solution and adds folder creation to the `kptfile` pipeline.