### PR TITLE
Add include children in Audit Sink

### DIFF
--- a/.github/workflows/guardrails-validation.yaml
+++ b/.github/workflows/guardrails-validation.yaml
@@ -30,4 +30,4 @@ jobs:
         run: pwd && ls
       - name: nomos vet guardrails
         run: |
-          docker run -v $PWD:/guardrails gcr.io/config-management-release/nomos:stable nomos vet --no-api-server-check --source-format unstructured --path /guardrails/configs
+          ls && docker run -v $PWD:/guardrails gcr.io/config-management-release/nomos:stable nomos vet --no-api-server-check --source-format unstructured --path /guardrails/configs

--- a/solutions/landing-zone/environments/common/audit/audit-bucket.yaml
+++ b/solutions/landing-zone/environments/common/audit/audit-bucket.yaml
@@ -23,6 +23,7 @@ spec:
   organizationRef:
     # Replace "${ORG_ID?}" with the numeric ID for your organization
     external: "${ORG_ID?}" # kpt-set: ${org-id}
+  includeChildren: true
   destination:
     storageBucketRef:
       # StorageBucket names must be globally unique. Replace ${PROJECT_ID?} with your project ID.


### PR DESCRIPTION
This PR will add the missing `includeChildren` key to the Organization LogSink and sets it to `true`.