### PR TITLE
updated test path

### DIFF
--- a/.github/workflows/guardrails-validation.yaml
+++ b/.github/workflows/guardrails-validation.yaml
@@ -30,4 +30,4 @@ jobs:
         run: pwd && ls
       - name: nomos vet guardrails
         run: |
-          ls && docker run -v $PWD:/guardrails gcr.io/config-management-release/nomos:stable nomos vet --no-api-server-check --source-format unstructured --path /guardrails/configs
+          docker run -v $PWD:/guardrails gcr.io/config-management-release/nomos:stable nomos vet --no-api-server-check --source-format unstructured --path /guardrails/guardrails/configs


### PR DESCRIPTION
Updated path for guardrails solution in Nomos command.

CI test now works, see https://github.com/cartyc/pubsec-declarative-toolkit/actions/runs/3244668299 for a successful run.