### PR TITLE
resolve #193 : fixed mutators by keeping enable-gcp-services last

### DIFF
--- a/solutions/landing-zone-namespaced/landing-zone/Kptfile
+++ b/solutions/landing-zone-namespaced/landing-zone/Kptfile
@@ -10,8 +10,8 @@ pipeline:
   mutators:
     - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml  
-    - image: gcr.io/kpt-fn/enable-gcp-services:v0.1.0
     - image: gcr.io/kpt-fn/generate-folders:v0.1.1
+    - image: gcr.io/kpt-fn/enable-gcp-services:v0.1.0
   validators:
     - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
     - image: gcr.io/kpt-fn/kubeval:v0.3.0

--- a/solutions/landing-zone-namespaced/landing-zone/setters.yaml
+++ b/solutions/landing-zone-namespaced/landing-zone/setters.yaml
@@ -47,7 +47,7 @@ data:
   # Cannot contain restricted strings, such as google and ssl.
   net-host-prj-nonprod-id: net-host-prj-nonprod-12345
   net-host-prj-prod-id: net-host-prj-prod-12345
-  net-perimeter-prj-common-id: net-perimeter-prj-common-12345
+  net-perimeter-prj-common-id: net-per-prj-common-12345
   audit-prj-id: audit-prj-id-12345
   guardrails-project-id: guardrails-project-12345
   #############
@@ -57,3 +57,4 @@ data:
   log-writer: group@domain.com
   log-reader: group@domain.com
   organization-viewer: group@domain.com
+  


### PR DESCRIPTION
merging latest updates to solutions/landing-zone
fix mutator sequence to ensure the enable-gcp-services remains last to avoid the bug where single quote gets replaced by double quote or no quotes