### PR TITLE
fix: Nomos update

### DIFF
--- a/.github/workflows/guardrails-validation.yaml
+++ b/.github/workflows/guardrails-validation.yaml
@@ -30,4 +30,4 @@ jobs:
         run: pwd && ls
       - name: nomos vet guardrails
         run: |
-          docker run -v $PWD:/guardrails gcr.io/config-management-release/nomos:stable nomos vet --no-api-server-check --source-format unstructured --path /guardrails/guardrails/configs
+          docker run -v $PWD:/guardrails gcr.io/config-management-release/nomos:v1.13.1 nomos vet --no-api-server-check --source-format unstructured --path /guardrails/guardrails/configs

--- a/.github/workflows/landing-zone-validation.yaml
+++ b/.github/workflows/landing-zone-validation.yaml
@@ -30,4 +30,4 @@ jobs:
         run: pwd && ls
       - name: nomos vet landing-zone
         run: |
-          docker run -v $PWD:/landing-zone gcr.io/config-management-release/nomos:stable nomos vet --no-api-server-check --source-format unstructured --path /landing-zone/landing-zone/environments
+          docker run -v $PWD:/landing-zone gcr.io/config-management-release/nomos:v1.13.1 nomos vet --no-api-server-check --source-format unstructured --path /landing-zone/landing-zone/environments


### PR DESCRIPTION
Updated the nomos container to use `v1.13.1` instead of `stable`. The latest stable release does not include the `nomos` binary which has been causing the validation actions to fail.

Reverting to `v1.13.1` as the `nomos` binary is included in that release.

Will squash the merge as there are a few additional empty commits where I added a verified commit.