### PR TITLE
fix: updated default regions for sandbox-gke and private-sql examples

### DIFF
--- a/services/private-sql/fn-setters.yaml
+++ b/services/private-sql/fn-setters.yaml
@@ -18,7 +18,7 @@ metadata:
   name: setters
 data:
   project-id: CHANGE-PROJECTID
-  region: us-central1
+  region: northamerica-northeast1
   network-name: default
   sql-db-name: my-sql-db
   sql-user: my-sql-user

--- a/services/private-sql/sql.yaml
+++ b/services/private-sql/sql.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: CHANGE-NAMESPACE
 spec:
   databaseVersion: POSTGRES_13
-  region: us-central1 # kpt-set: ${region}
+  region: northamerica-northeast1 # kpt-set: ${region}
   settings:
     activationPolicy: ALWAYS
     availabilityType: ZONAL

--- a/solutions/sandbox-gke/README.md
+++ b/solutions/sandbox-gke/README.md
@@ -54,7 +54,7 @@ The following fields are exposed in `setters.yaml`
 | gke-admin | group@email.com | |
 | gke-viewer | group@email.com | |
 | machineType | e2-standard-4 | |
-| region | us-central1 | |
+| region | northamerica-northeast1 | |
 
 4. To populate the template with the `setters` inputs run `kpt fn render`.
 

--- a/solutions/sandbox-gke/artifact-registry/registry.yaml
+++ b/solutions/sandbox-gke/artifact-registry/registry.yaml
@@ -20,7 +20,7 @@ metadata:
     environment: sandbox
   annotations:
     cnrm.cloud.google.com/project-id: "sandbox-000000" # kpt-set: ${project-id}
-    config.kubernetes.io/depends-on: serviceusage.cnrm.cloud.google.com/v1beta1/namespaces/config-control/Service/my-demo-guardrails-controller-services-artifactregistry # kpt-set: serviceusage.cnrm.cloud.google.com/v1beta1/namespaces/${project-namespace}/Service/${project-id}-services-artifactregistry
+    config.kubernetes.io/depends-on: serviceusage.cnrm.cloud.google.com/namespaces/config-control/Service/my-demo-guardrails-controller-services-artifactregistry # kpt-set: serviceusage.cnrm.cloud.google.com/namespaces/${project-namespace}/Service/${project-id}-services-artifactregistry
 spec:
   description: "Example Container Registry"
   format: DOCKER

--- a/solutions/sandbox-gke/artifact-registry/registry.yaml
+++ b/solutions/sandbox-gke/artifact-registry/registry.yaml
@@ -24,4 +24,4 @@ metadata:
 spec:
   description: "Example Container Registry"
   format: DOCKER
-  location: us-northamerica-northeast1 # kpt-set: ${region}
+  location: northamerica-northeast1 # kpt-set: ${region}

--- a/solutions/sandbox-gke/network/computerouter.yaml
+++ b/solutions/sandbox-gke/network/computerouter.yaml
@@ -23,4 +23,4 @@ spec:
   description: example router description
   networkRef:
     name: sandbox-net # kpt-set: ${network-name}
-  region: us-central1 # kpt-set: ${region}
+  region: northamerica-northeast1 # kpt-set: ${region}

--- a/solutions/sandbox-gke/network/computerouternat.yaml
+++ b/solutions/sandbox-gke/network/computerouternat.yaml
@@ -21,7 +21,7 @@ metadata: # kpt-merge: ${NAMESPACE}/computerouternat-sample-forallsubnets
     cnrm.cloud.google.com/project-id: "sandbox-000000" # kpt-set: ${project-id}
 spec:
   natIpAllocateOption: AUTO_ONLY
-  region: us-central1 # kpt-set: ${region}
+  region: northamerica-northeast1 # kpt-set: ${region}
   routerRef:
     name: router-sandbox-net # kpt-set: router-${network-name}
   sourceSubnetworkIpRangesToNat: LIST_OF_SUBNETWORKS

--- a/solutions/sandbox-gke/network/subnetwork.yaml
+++ b/solutions/sandbox-gke/network/subnetwork.yaml
@@ -23,7 +23,7 @@ spec:
   ipCidrRange: 10.2.0.0/16 # kpt-set: ${subnet-cidr}
   networkRef:
     name: sandbox-net # kpt-set: ${network-name}
-  region: us-central1 # kpt-set: ${region}
+  region: northamerica-northeast1 # kpt-set: ${region}
   privateIpGoogleAccess: true # kpt-set: ${private-google-access}
   logConfig:
     aggregationInterval: INTERVAL_10_MIN # kpt-set: ${log-aggreation-interval}

--- a/solutions/sandbox-gke/private-gke/gke/bigquerydataset.yaml
+++ b/solutions/sandbox-gke/private-gke/gke/bigquerydataset.yaml
@@ -26,4 +26,4 @@ spec:
   defaultTableExpirationMs: 3600000
   description: "BigQuery Dataset Sample" # kpt-set: ${cluster-name}-gkemetering
   friendlyName: gke-metering-dataset
-  location: us-central1 # kpt-set: ${region}
+  location: northamerica-northeast1 # kpt-set: ${region}

--- a/solutions/sandbox-gke/private-gke/gke/containercluster.yaml
+++ b/solutions/sandbox-gke/private-gke/gke/containercluster.yaml
@@ -37,7 +37,7 @@ spec:
   ipAllocationPolicy:
     clusterSecondaryRangeName: podrange # kpt-set: ${gke-pod-range-name}
     servicesSecondaryRangeName: servicesrange # kpt-set: ${gke-services-range-name}
-  location: us-central1 # kpt-set: ${region}
+  location: northamerica-northeast1 # kpt-set: ${region}
   maintenancePolicy:
     dailyMaintenanceWindow:
       startTime: 01:00

--- a/solutions/sandbox-gke/setters.yaml
+++ b/solutions/sandbox-gke/setters.yaml
@@ -70,4 +70,4 @@ data:
   # https://cloud.google.com/compute/docs/machine-types
   #
   machineType: e2-standard-4
-  region: us-central1
+  region: northamerica-northeast1


### PR DESCRIPTION
This is a small  PR that addresses the mislabeled regions  mentioned in #278 and sets any remaining regions set to use `us-central1` to be `northamerica-northeast1` as a default.