### PR TITLE
feat: logging client-env package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -11,5 +11,6 @@
     "solutions/project/hub-env": "0.2.0",
     "solutions/project/spoke-unclass-env": "0.1.0",
     "solutions/logging/client-experimentation": "0.2.0",
-    "solutions/logging/core-experimentation": "0.2.1"
+    "solutions/logging/core-experimentation": "0.2.1",
+    "solutions/logging/client-env": "0.0.1"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -12,5 +12,6 @@
     "solutions/project/spoke-unclass-env": "0.1.0",
     "solutions/logging/client-experimentation": "0.2.0",
     "solutions/logging/core-experimentation": "0.2.1",
+    "solutions/logging/core-env": "0.1.0",
     "solutions/logging/client-env": "0.0.1"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -11,5 +11,5 @@
     "solutions/project/hub-env": "0.2.0",
     "solutions/project/spoke-unclass-env": "0.1.0",
     "solutions/logging/client-experimentation": "0.2.0",
-    "solutions/logging/core-experimentation": "0.2.0"
+    "solutions/logging/core-experimentation": "0.2.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -52,6 +52,11 @@
       "tag-separator": "/",
       "prerelease": true
     },
+    "solutions/logging/client-env": {
+      "package-name": "solutions/logging/client-env",
+      "tag-separator": "/",
+      "prerelease": true
+    },
     "solutions/org-policies": {
       "package-name": "solutions/org-policies",
       "tag-separator": "/",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -52,6 +52,11 @@
       "tag-separator": "/",
       "prerelease": true
     },
+    "solutions/logging/client-core": {
+      "package-name": "solutions/logging/client-core",
+      "tag-separator": "/",
+      "prerelease": true
+    },
     "solutions/logging/client-env": {
       "package-name": "solutions/logging/client-env",
       "tag-separator": "/",

--- a/solutions/logging/client-env/Kptfile
+++ b/solutions/logging/client-env/Kptfile
@@ -1,0 +1,15 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: client-env-logging-package
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description:  |
+    Landing zone v2 subpackage.
+    Package to deploy client-env logging solution.
+    The core-env logging package must be deployed before this package.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/logging/client-env/README.md
+++ b/solutions/logging/client-env/README.md
@@ -9,13 +9,13 @@ The core-env logging package must be deployed before this package.
 
 ## Setters
 
-|           Name           |        Value         | Type | Count |
-|--------------------------|----------------------|------|-------|
-| client-displayname       | Client1              | str  |     2 |
-| client-name              | client1              | str  |     5 |
-| logging-prj-id           | logging-prj-id-12345 | str  |     4 |
-| retention-in-days        |                    1 | int  |     1 |
-| retention-locking-policy | false                | bool |     1 |
+|           Name           |       Value        | Type | Count |
+|--------------------------|--------------------|------|-------|
+| client-displayname       | Client1            | str  |     2 |
+| client-name              | client1            | str  |     5 |
+| logging-project-id       | logging-project-id | str  |     4 |
+| retention-in-days        |                  1 | int  |     1 |
+| retention-locking-policy | false              | bool |     1 |
 
 ## Sub-packages
 

--- a/solutions/logging/client-env/README.md
+++ b/solutions/logging/client-env/README.md
@@ -14,8 +14,8 @@ The core-env logging package must be deployed before this package.
 | client-displayname       | Client1            | str  |     2 |
 | client-name              | client1            | str  |     5 |
 | logging-project-id       | logging-project-id | str  |     4 |
-| retention-in-days        |                  1 | int  |     1 |
-| retention-locking-policy | false              | bool |     1 |
+| retention-in-days        |                365 | int  |     1 |
+| retention-locking-policy | true               | bool |     1 |
 
 ## Sub-packages
 

--- a/solutions/logging/client-env/README.md
+++ b/solutions/logging/client-env/README.md
@@ -1,0 +1,85 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# client-env-logging-package
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+Landing zone v2 subpackage.
+Package to deploy client-env logging solution.
+The core-env logging package must be deployed before this package.
+
+## Setters
+
+|           Name           |        Value         | Type | Count |
+|--------------------------|----------------------|------|-------|
+| client-displayname       | Client1              | str  |     2 |
+| client-name              | client1              | str  |     5 |
+| logging-prj-id           | logging-prj-id-12345 | str  |     4 |
+| retention-in-days        |                    1 | int  |     1 |
+| retention-locking-policy | false                | bool |     1 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|           File            |              APIVersion               |       Kind       |                             Name                             | Namespace |
+|---------------------------|---------------------------------------|------------------|--------------------------------------------------------------|-----------|
+| cloud-logging-bucket.yaml | logging.cnrm.cloud.google.com/v1beta1 | LoggingLogBucket | platform-and-component-client1-log-bucket                    | logging   |
+| folder-sink.yaml          | logging.cnrm.cloud.google.com/v1beta1 | LoggingLogSink   | platform-and-component-log-client1-log-sink                  | logging   |
+| project-iam.yaml          | iam.cnrm.cloud.google.com/v1beta1     | IAMPartialPolicy | platform-and-component-log-client1-bucket-writer-permissions | projects  |
+
+## Resource References
+
+- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
+- [LoggingLogBucket](https://cloud.google.com/config-connector/docs/reference/resource-docs/logging/logginglogbucket)
+- [LoggingLogSink](https://cloud.google.com/config-connector/docs/reference/resource-docs/logging/logginglogsink)
+
+## Usage
+
+1.  Clone the package:
+
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/logging/client-env/client-env-logging-package@${VERSION}
+    ```
+
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+
+    ```shell
+    cd "./client-env-logging-package/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/logging/client-env/README.md
+++ b/solutions/logging/client-env/README.md
@@ -14,8 +14,8 @@ The core-env logging package must be deployed before this package.
 | client-displayname       | Client1            | str  |     2 |
 | client-name              | client1            | str  |     5 |
 | logging-project-id       | logging-project-id | str  |     4 |
-| retention-in-days        |                365 | int  |     1 |
-| retention-locking-policy | true               | bool |     1 |
+| retention-in-days        |                  1 | int  |     1 |
+| retention-locking-policy | false              | bool |     1 |
 
 ## Sub-packages
 

--- a/solutions/logging/client-env/cloud-logging-bucket.yaml
+++ b/solutions/logging/client-env/cloud-logging-bucket.yaml
@@ -21,11 +21,10 @@ metadata:
   name: platform-and-component-client1-log-bucket # kpt-set: platform-and-component-${client-name}-log-bucket
   namespace: logging
   annotations:
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-prj-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-prj-id}
-    internal.kpt.dev/upstream-identifier: 'logging.cnrm.cloud.google.com|LoggingLogBucket|logging|platform-and-component-client1-log-bucket'
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id}
 spec:
   projectRef:
-    name: logging-prj-id # kpt-set: ${logging-prj-id}
+    name: logging-project-id # kpt-set: ${logging-project-id}
     namespace: projects
   location: northamerica-northeast1
   description: Cloud Logging bucket for client Platform and Component logs # kpt-set: Cloud Logging bucket for ${client-displayname} Platform and Component logs

--- a/solutions/logging/client-env/cloud-logging-bucket.yaml
+++ b/solutions/logging/client-env/cloud-logging-bucket.yaml
@@ -30,5 +30,5 @@ spec:
   description: Cloud Logging bucket for client Platform and Component logs # kpt-set: Cloud Logging bucket for ${client-displayname} Platform and Component logs
   # Implement retention policy and retention locking policy
   # AU-9, AU-11 - RetentionDays sets the policy where existing log content cannot be changed/deleted for the specificied number of days (from setters.yaml), locked setting means policy cannot be changed, ensuring immutability.
-  locked: true # kpt-set: ${retention-locking-policy}
-  retentionDays: 365 # kpt-set: ${retention-in-days}
+  locked: false # kpt-set: ${retention-locking-policy}
+  retentionDays: 1 # kpt-set: ${retention-in-days}

--- a/solutions/logging/client-env/cloud-logging-bucket.yaml
+++ b/solutions/logging/client-env/cloud-logging-bucket.yaml
@@ -1,0 +1,35 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Cloud Logging bucket for client Platform and Component logs
+# Logs are routed using a log sink to a central logging project into a dedicated log bucket
+# AU-4(1), AU-9(2) - Log buckets are created in a logging project, isolating them from the source of the log entries in other projects
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogBucket
+metadata:
+  name: platform-and-component-client1-log-bucket # kpt-set: platform-and-component-${client-name}-log-bucket
+  namespace: logging
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-prj-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-prj-id}
+    internal.kpt.dev/upstream-identifier: 'logging.cnrm.cloud.google.com|LoggingLogBucket|logging|platform-and-component-client1-log-bucket'
+spec:
+  projectRef:
+    name: logging-prj-id # kpt-set: ${logging-prj-id}
+    namespace: projects
+  location: northamerica-northeast1
+  description: Cloud Logging bucket for client Platform and Component logs # kpt-set: Cloud Logging bucket for ${client-displayname} Platform and Component logs
+  # Implement retention policy and retention locking policy
+  # AU-9, AU-11 - RetentionDays sets the policy where existing log content cannot be changed/deleted for the specificied number of days (from setters.yaml), locked setting means policy cannot be changed, ensuring immutability.
+  locked: false # kpt-set: ${retention-locking-policy}
+  retentionDays: 1 # kpt-set: ${retention-in-days}

--- a/solutions/logging/client-env/cloud-logging-bucket.yaml
+++ b/solutions/logging/client-env/cloud-logging-bucket.yaml
@@ -30,5 +30,5 @@ spec:
   description: Cloud Logging bucket for client Platform and Component logs # kpt-set: Cloud Logging bucket for ${client-displayname} Platform and Component logs
   # Implement retention policy and retention locking policy
   # AU-9, AU-11 - RetentionDays sets the policy where existing log content cannot be changed/deleted for the specificied number of days (from setters.yaml), locked setting means policy cannot be changed, ensuring immutability.
-  locked: false # kpt-set: ${retention-locking-policy}
-  retentionDays: 1 # kpt-set: ${retention-in-days}
+  locked: true # kpt-set: ${retention-locking-policy}
+  retentionDays: 365 # kpt-set: ${retention-in-days}

--- a/solutions/logging/client-env/folder-sink.yaml
+++ b/solutions/logging/client-env/folder-sink.yaml
@@ -21,7 +21,6 @@ metadata:
   namespace: logging
   annotations:
     config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/platform-and-component-client1-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/platform-and-component-${client-name}-log-bucket
-    internal.kpt.dev/upstream-identifier: 'logging.cnrm.cloud.google.com|LoggingLogSink|logging|platform-and-component-log-client1-log-sink'
 spec:
   folderRef:
     name: clients.client1 # kpt-set: clients.${client-name}
@@ -31,13 +30,13 @@ spec:
     loggingLogBucketRef:
       # destination.loggingLogBucketRef
       # Only `external` field is supported to configure the reference.
-      external: platform-and-component-client1-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-prj-id}/locations/northamerica-northeast1/buckets/platform-and-component-${client-name}-log-bucket
+      external: platform-and-component-client1-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/platform-and-component-${client-name}-log-bucket
   description: Folder sink for Client Platform and Component logs # kpt-set: Folder sink for ${client-displayname} Platform and Component logs
   # AU-2, AU-12(A), AU-12(C)
   # Includes the following types of logs:
   # Cloud DNS, Cloud NAT, Firewall Rules, VPC Flow, and HTTP(S) Load Balancer
-  # These logs are not enabled by default. They are enabled inside the client-experimentation package:
-  # https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/project/project-experimentation
+  # These logs are not enabled by default. They are enabled inside the client-env package:
+  # https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/project/project-env
   filter: |-
     LOG_ID("dns.googleapis.com/dns_queries")
     OR (LOG_ID("compute.googleapis.com/nat_flows") AND resource.type="nat_gateway")

--- a/solutions/logging/client-env/folder-sink.yaml
+++ b/solutions/logging/client-env/folder-sink.yaml
@@ -35,8 +35,7 @@ spec:
   # AU-2, AU-12(A), AU-12(C)
   # Includes the following types of logs:
   # Cloud DNS, Cloud NAT, Firewall Rules, VPC Flow, and HTTP(S) Load Balancer
-  # These logs are not enabled by default. They are enabled inside the client-env package:
-  # https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/project/project-env
+  # Logs for such resources must be enabled on the respective resource as they are not enabled by default.
   filter: |-
     LOG_ID("dns.googleapis.com/dns_queries")
     OR (LOG_ID("compute.googleapis.com/nat_flows") AND resource.type="nat_gateway")

--- a/solutions/logging/client-env/folder-sink.yaml
+++ b/solutions/logging/client-env/folder-sink.yaml
@@ -1,0 +1,57 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Folder sink for Platform and Component logs of Client Resources
+# Destination: cloud logging bucket inside logging project
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogSink
+metadata:
+  name: platform-and-component-log-client1-log-sink # kpt-set: platform-and-component-log-${client-name}-log-sink
+  namespace: logging
+  annotations:
+    config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/platform-and-component-client1-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/platform-and-component-${client-name}-log-bucket
+    internal.kpt.dev/upstream-identifier: 'logging.cnrm.cloud.google.com|LoggingLogSink|logging|platform-and-component-log-client1-log-sink'
+spec:
+  folderRef:
+    name: clients.client1 # kpt-set: clients.${client-name}
+    namespace: hierarchy
+  includeChildren: true
+  destination:
+    loggingLogBucketRef:
+      # destination.loggingLogBucketRef
+      # Only `external` field is supported to configure the reference.
+      external: platform-and-component-client1-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-prj-id}/locations/northamerica-northeast1/buckets/platform-and-component-${client-name}-log-bucket
+  description: Folder sink for Client Platform and Component logs # kpt-set: Folder sink for ${client-displayname} Platform and Component logs
+  # AU-2, AU-12(A), AU-12(C)
+  # Includes the following types of logs:
+  # Cloud DNS, Cloud NAT, Firewall Rules, VPC Flow, and HTTP(S) Load Balancer
+  # These logs are not enabled by default. They are enabled inside the client-experimentation package:
+  # https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/project/project-experimentation
+  filter: |-
+    LOG_ID("dns.googleapis.com/dns_queries")
+    OR (LOG_ID("compute.googleapis.com/nat_flows") AND resource.type="nat_gateway")
+    OR (LOG_ID("compute.googleapis.com/firewall") AND resource.type="gce_subnetwork")
+    OR (LOG_ID("compute.googleapis.com/vpc_flows") AND resource.type="gce_subnetwork")
+    OR (LOG_ID("requests") AND resource.type="http_load_balancer")
+  # Excludes all Security logs: Cloud Audit, Access Transparency, and Data Access Logs
+  exclusions:
+    - description: Exclude Security logs
+      disabled: false
+      filter: |-
+        LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("externalaudit.googleapis.com/activity")
+        OR LOG_ID("cloudaudit.googleapis.com/data_access") OR LOG_ID("externalaudit.googleapis.com/data_access")
+        OR LOG_ID("cloudaudit.googleapis.com/system_event") OR LOG_ID("externalaudit.googleapis.com/system_event")
+        OR LOG_ID("cloudaudit.googleapis.com/policy") OR LOG_ID("externalaudit.googleapis.com/policy")
+        OR LOG_ID("cloudaudit.googleapis.com/access_transparency") OR LOG_ID("externalaudit.googleapis.com/access_transparency")
+      name: exclude-security-logs

--- a/solutions/logging/client-env/project-iam.yaml
+++ b/solutions/logging/client-env/project-iam.yaml
@@ -20,12 +20,11 @@ metadata:
   name: platform-and-component-log-client1-bucket-writer-permissions # kpt-set: platform-and-component-log-${client-name}-bucket-writer-permissions
   namespace: projects
   annotations:
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-prj-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-prj-id}
-    internal.kpt.dev/upstream-identifier: 'iam.cnrm.cloud.google.com|IAMPartialPolicy|projects|platform-and-component-log-client1-bucket-writer-permissions'
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id}
 spec:
   resourceRef:
     kind: Project
-    name: logging-prj-id # kpt-set: ${logging-prj-id}
+    name: logging-project-id # kpt-set: ${logging-project-id}
     namespace: projects
   # AC-3(7) - Write access to the logging bucket is limited by IAM to just the identity of the log sink configured to send logs to the bucket (set at the logging project level)
   bindings:

--- a/solutions/logging/client-env/project-iam.yaml
+++ b/solutions/logging/client-env/project-iam.yaml
@@ -1,0 +1,37 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Logs Bucket writer IAM permissions
+# Binds the generated Writer identity from the LoggingLogSink to the logging project
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata:
+  name: platform-and-component-log-client1-bucket-writer-permissions # kpt-set: platform-and-component-log-${client-name}-bucket-writer-permissions
+  namespace: projects
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-prj-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-prj-id}
+    internal.kpt.dev/upstream-identifier: 'iam.cnrm.cloud.google.com|IAMPartialPolicy|projects|platform-and-component-log-client1-bucket-writer-permissions'
+spec:
+  resourceRef:
+    kind: Project
+    name: logging-prj-id # kpt-set: ${logging-prj-id}
+    namespace: projects
+  # AC-3(7) - Write access to the logging bucket is limited by IAM to just the identity of the log sink configured to send logs to the bucket (set at the logging project level)
+  bindings:
+    - role: roles/logging.bucketWriter
+      members:
+        - memberFrom:
+            logSinkRef:
+              name: platform-and-component-log-client1-sink # kpt-set: platform-and-component-log-${client-name}-log-sink
+              namespace: logging

--- a/solutions/logging/client-env/securitycontrols.md
+++ b/solutions/logging/client-env/securitycontrols.md
@@ -1,23 +1,23 @@
 # Security Controls
 
-### AC-3(7) ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+## AC-3(7) ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
 
 AC-3(7) – Write access to the logs is constrained by IAM permissions to just the log sinks.
-Added this control to project-iam.yaml in bindings where bucketWriter role is assigned. 
+Added this control to project-iam.yaml in bindings where bucketWriter role is assigned.
 
 ## AU-2 AUDITABLE EVENTS
 
 AU-2 – Event families being audited are set here. Added this control to folder-sink.yaml immediately
 preceeding the filter including/exluding various log types
 
-Ops Note: This is an org control so the AU-2 tagging in the code is there to support the narrative Ops 
+Ops Note: This is an org control so the AU-2 tagging in the code is there to support the narrative Ops
 will write to demonstrate the org requirements
 
-### AU-4(1) AUDIT STORAGE CAPACITY | TRANSFER TO ALTERNATE STORAGE
+## AU-4(1) AUDIT STORAGE CAPACITY | TRANSFER TO ALTERNATE STORAGE
 
 AU-4(1) – Logs are being sent to a logging project which is separate from the projects
 performing actions which generate log entries. Added to the cloud-logging-buckets.yaml
-where separate logging project is selected as target. 
+where separate logging project is selected as target.
 
 ## AU-8 TIME STAMPS
 
@@ -26,11 +26,11 @@ RFC3339 UTC format in log entries (see GCP documentation for LogEntry object, ti
 
 ## AU-9 PROTECTION OF AUDIT INFORMATION
 
-AU-9 – Retention policies and policy locks are implemented so log contents is immutable. Added to 
+AU-9 – Retention policies and policy locks are implemented so log contents is immutable. Added to
 cloud-logging-buckets.yaml prior to locked and retentionDays entrie. Also added to setters.yaml
 as previous entries are set from here.
 
-### AU-9(2) PROTECTION OF AUDIT INFORMATION | AUDIT BACKUP ON SEPARATE PHYSICAL SYSTEMS / COMPONENTS
+## AU-9(2) PROTECTION OF AUDIT INFORMATION | AUDIT BACKUP ON SEPARATE PHYSICAL SYSTEMS / COMPONENTS
 
 AU-9(2) – Logs sent to separate project, same response as AU-4(1)
 
@@ -38,10 +38,10 @@ AU-9(2) – Logs sent to separate project, same response as AU-4(1)
 
 AU-11 – Audit log retention, same response as AU-9
 
-### AU-12(A) AUDIT GENERATION
+## AU-12(A) AUDIT GENERATION
 
 Same as AU-2 (this control is the implementation of AU-2)
 
-### AU-12(C) AUDIT GENERATION
+## AU-12(C) AUDIT GENERATION
 
 Same as AU-2 (this control is the implementation of AU-2)

--- a/solutions/logging/client-env/securitycontrols.md
+++ b/solutions/logging/client-env/securitycontrols.md
@@ -1,0 +1,51 @@
+# Security Controls
+>
+> TODO: This document requires refinement.
+
+## AC-3 ACCESS ENFORCEMENT
+
+### AC-3(7) ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+
+AC-3(7) – Write access to the logs is constrained by IAM permissions to just the log sinks.
+This control should be added to project-iam.yaml. Lines 15/16 already have a good explanation of
+what’s happening so just add the AC-3(7) tag around there)
+
+## AU-2 AUDITABLE EVENTS
+
+AU-2 – Event families being audited are set here. This control should be added to the folder-sink.yaml,
+gke-kcc-sink.yaml and org-sink.yaml with a brief explanation of what’s being audited.
+Suggest putting the tag and explanation down around line 35 where the inclusions/exclusions are
+This is an org control so the AU-2 tagging in the code is there to support the narrative Ops will write to demonstrate the org requirements
+
+## AU-4 AUDIT STORAGE CAPACITY
+
+### AU-4(1) AUDIT STORAGE CAPACITY | TRANSFER TO ALTERNATE STORAGE
+
+AU-4(1) – Logs are being sent to a logging project which is separate from the projects
+performing actions which generate log entries. This control should be added to the
+cloud-logging-buckets.yaml with a brief explanation that the logs are in a separate project.
+Suggest putting around line 15 which describes buckets
+
+## AU-8 TIME STAMPS
+
+AU-8 – Time stamps for audit records use internal Google time. Statement to that effect should go into securitycontrols.md, will need a reference to some Google documentation (can be found later)
+
+## AU-9 PROTECTION OF AUDIT INFORMATION
+
+AU-9 – Retention policies and policy locks are implemented so log contents is immutable. Include in cloud-logging-buckets.yaml after lines 28 and 46 (i.e. just before the “locked” and “retentionDays” settings. Also add to setters.yaml. Also add notation to project-iam.yaml where roles are being assigned to the sinks (same as AC-3(7))
+
+### AU-9(2) PROTECTION OF AUDIT INFORMATION | AUDIT BACKUP ON SEPARATE PHYSICAL SYSTEMS / COMPONENTS
+
+AU-9(2) – Logs sent to separate project, same response as AU-4(1)
+
+## AU-11 AUDIT RECORD RETENTION
+
+AU-11 – Audit log retention, same response as AU-9 however no reference added to project-iam.yaml as AU-11 doesn’t deal with access
+
+## AU-12 AUDIT GENERATION
+
+### AU-12(A)
+
+### AU-12(C)
+
+AU-12(A), AU-12(C) – This is the implementation of AU-2, so same comments and code locations apply

--- a/solutions/logging/client-env/setters.yaml
+++ b/solutions/logging/client-env/setters.yaml
@@ -31,5 +31,5 @@ data:
   # After a retention policy is locked (true), you can't delete the bucket until every log in the bucket has fulfilled the bucket's retention period
   # AU-9 PROTECTION OF AUDIT INFORMATION
   # AU-11 AUDIT RECORD RETENTION
-  retention-locking-policy: false
-  retention-in-days: 1
+  retention-locking-policy: true
+  retention-in-days: 365

--- a/solutions/logging/client-env/setters.yaml
+++ b/solutions/logging/client-env/setters.yaml
@@ -31,5 +31,6 @@ data:
   # After a retention policy is locked (true), you can't delete the bucket until every log in the bucket has fulfilled the bucket's retention period
   # AU-9 PROTECTION OF AUDIT INFORMATION
   # AU-11 AUDIT RECORD RETENTION
-  retention-locking-policy: true
-  retention-in-days: 365
+  # The values below must be modified to locked: true and retentionDays: 365 in a Production setting to implement above mentioned security controls.
+  retention-locking-policy: false
+  retention-in-days: 1

--- a/solutions/logging/client-env/setters.yaml
+++ b/solutions/logging/client-env/setters.yaml
@@ -18,13 +18,12 @@ metadata:
   name: setters
   annotations:
     config.kubernetes.io/local-config: "true"
-    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|setters'
 data:
   client-name: 'client1' # lowercase only
   client-displayname: 'Client1'
   #############
   # logging Project ID
-  logging-prj-id: logging-prj-id-12345
+  logging-project-id: logging-project-id
   #############
   # LoggingLogBucket retention settings
   # Set the number of days to retain logs in Cloud Logging buckets

--- a/solutions/logging/client-env/setters.yaml
+++ b/solutions/logging/client-env/setters.yaml
@@ -1,0 +1,36 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|setters'
+data:
+  client-name: 'client1' # lowercase only
+  client-displayname: 'Client1'
+  #############
+  # logging Project ID
+  logging-prj-id: logging-prj-id-12345
+  #############
+  # LoggingLogBucket retention settings
+  # Set the number of days to retain logs in Cloud Logging buckets
+  # Set the lock mechanism on the bucket to: true or false
+  # After a retention policy is locked (true), you can't delete the bucket until every log in the bucket has fulfilled the bucket's retention period
+  # AU-9 PROTECTION OF AUDIT INFORMATION
+  # AU-11 AUDIT RECORD RETENTION
+  retention-locking-policy: false
+  retention-in-days: 1

--- a/solutions/logging/core-experimentation/CHANGELOG.md
+++ b/solutions/logging/core-experimentation/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.1](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/compare/solutions/logging/core-experimentation/0.2.0...solutions/logging/core-experimentation/0.2.1) (2023-04-17)
+
+
+### Bug Fixes
+
+* update org-sink bucket reference ([#335](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/issues/335)) ([0e3952a](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/commit/0e3952ac32913e197e84676691ed651496e31e21))
+
 ## [0.2.0](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/compare/solutions/logging/core-experimentation/0.1.0...solutions/logging/core-experimentation/0.2.0) (2023-03-21)
 
 

--- a/solutions/logging/core-experimentation/org-sink.yaml
+++ b/solutions/logging/core-experimentation/org-sink.yaml
@@ -29,7 +29,7 @@ spec:
     loggingLogBucketRef:
       # destination.loggingLogBucketRef
       # Only `external` field is supported to configure the reference.
-      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-prj-id}/locations/northamerica-northeast1/buckets/logging-log-bucket
+      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-prj-id}/locations/northamerica-northeast1/buckets/security-log-bucket
   description: Organization sink for Security Logs
   # AU-2, AU-12(A), AU-12(C)
   # Includes Security logs: Cloud Audit, Access Transparency, and Data Access Logs


### PR DESCRIPTION
This, along with the core-env logging package closes #337
- initial deployment of client-env logging package
- implementation is dependent on core-env logging package