### PR TITLE
fix: add monitoring namespace and resources for gke metrics

### DIFF
--- a/solutions/landing-zone-v2/README.md
+++ b/solutions/landing-zone-v2/README.md
@@ -10,23 +10,21 @@ public sector declarative toolkit - landing zone v2 solution
 
 ## Setters
 
-|            Name             |           Value            | Type | Count |
-|-----------------------------|----------------------------|------|-------|
-| audit-prj-id                | audit-prj-id-12345         | str  |     0 |
-| audit-viewer                | group@domain.com           | str  |     0 |
-| billing-id                  |                 0000000000 | str  |     0 |
-| guardrails-project-id       | guardrails-project-12345   | str  |     0 |
-| log-reader                  | group@domain.com           | str  |     0 |
-| log-writer                  | group@domain.com           | str  |     0 |
-| lz-folder-id                |                 0000000000 | str  |    12 |
-| management-namespace        | config-control             | str  |    26 |
-| management-project-id       | management-project-12345   | str  |    52 |
-| management-project-number   |                 0000000000 | str  |     0 |
-| net-host-prj-nonprod-id     | net-host-prj-nonprod-12345 | str  |     0 |
-| net-host-prj-prod-id        | net-host-prj-prod-12345    | str  |     0 |
-| net-perimeter-prj-common-id | net-per-prj-common-12345   | str  |     0 |
-| org-id                      |                 0000000000 | str  |     3 |
-| organization-viewer         | group@domain.com           | str  |     0 |
+|           Name            |          Value           | Type | Count |
+|---------------------------|--------------------------|------|-------|
+| audit-prj-id              | audit-prj-id-12345       | str  |     0 |
+| audit-viewer              | group@domain.com         | str  |     0 |
+| billing-id                |               0000000000 | str  |     0 |
+| guardrails-project-id     | guardrails-project-12345 | str  |     0 |
+| hub-project-id            | hub-project-12345        | str  |     0 |
+| log-reader                | group@domain.com         | str  |     0 |
+| log-writer                | group@domain.com         | str  |     0 |
+| lz-folder-id              |               0000000000 | str  |    11 |
+| management-namespace      | config-control           | str  |    32 |
+| management-project-id     | management-project-12345 | str  |    64 |
+| management-project-number |               0000000000 | str  |     3 |
+| org-id                    |               0000000000 | str  |     5 |
+| organization-viewer       | group@domain.com         | str  |     0 |
 
 ## Sub-packages
 
@@ -34,49 +32,60 @@ This package has no sub-packages.
 
 ## Resources
 
-|            File            |              APIVersion              |          Kind          |                       Name                        |   Namespace    |
-|----------------------------|--------------------------------------|------------------------|---------------------------------------------------|----------------|
-| namespaces/hierarchy.yaml  | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | hierarchy-sa                                      | config-control |
-| namespaces/hierarchy.yaml  | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | hierarchy-sa-folderadmin-permissions              | config-control |
-| namespaces/hierarchy.yaml  | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | hierarchy-sa-workload-identity-binding            | config-control |
-| namespaces/hierarchy.yaml  | v1                                   | Namespace              | hierarchy                                         |                |
-| namespaces/hierarchy.yaml  | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | hierarchy      |
-| namespaces/hierarchy.yaml  | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-hierarchy-resource-reference-from-projects  | hierarchy      |
-| namespaces/hierarchy.yaml  | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-hierarchy-resource-reference-from-policies  | hierarchy      |
-| namespaces/logging.yaml    | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | logging-sa                                        | config-control |
-| namespaces/logging.yaml    | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | logging-sa-logadmin-permissions                   | config-control |
-| namespaces/logging.yaml    | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | logging-sa-bigqueryadmin-permissions              | config-control |
-| namespaces/logging.yaml    | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | logging-sa-workload-identity-binding              | config-control |
-| namespaces/logging.yaml    | v1                                   | Namespace              | logging                                           |                |
-| namespaces/logging.yaml    | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | logging        |
-| namespaces/networking.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | networking-sa                                     | config-control |
-| namespaces/networking.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | networking-sa-networkadmin-permissions            | config-control |
-| namespaces/networking.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | networking-sa-security-permissions                | config-control |
-| namespaces/networking.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | networking-sa-dns-permissions                     | config-control |
-| namespaces/networking.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | networking-sa-service-control-permissions         | config-control |
-| namespaces/networking.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | networking-sa-xpnadmin-permissions                | config-control |
-| namespaces/networking.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | networking-sa-workload-identity-binding           | config-control |
-| namespaces/networking.yaml | v1                                   | Namespace              | networking                                        |                |
-| namespaces/networking.yaml | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | networking     |
-| namespaces/policies.yaml   | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | policies-sa                                       | config-control |
-| namespaces/policies.yaml   | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | policies-sa-orgpolicyadmin-permissions            | config-control |
-| namespaces/policies.yaml   | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | policies-sa-workload-identity-binding             | config-control |
-| namespaces/policies.yaml   | v1                                   | Namespace              | policies                                          |                |
-| namespaces/policies.yaml   | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | policies       |
-| namespaces/projects.yaml   | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | projects-sa                                       | config-control |
-| namespaces/projects.yaml   | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-projectiamadmin-permissions           | config-control |
-| namespaces/projects.yaml   | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-projectcreator-permissions            | config-control |
-| namespaces/projects.yaml   | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-projectmover-permissions              | config-control |
-| namespaces/projects.yaml   | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-projectdeleter-permissions            | config-control |
-| namespaces/projects.yaml   | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-serviceusageadmin-permissions         | config-control |
-| namespaces/projects.yaml   | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-billinguser-permissions               | config-control |
-| namespaces/projects.yaml   | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | projects-sa-workload-identity-binding             | config-control |
-| namespaces/projects.yaml   | v1                                   | Namespace              | projects                                          |                |
-| namespaces/projects.yaml   | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | projects       |
-| namespaces/projects.yaml   | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-projects-resource-reference-from-logging    | projects       |
-| namespaces/projects.yaml   | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-projects-resource-reference-from-networking | projects       |
-| namespaces/projects.yaml   | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-projects-resource-reference-from-policies   | projects       |
-| services.yaml              | blueprints.cloud.google.com/v1alpha1 | ProjectServiceSet      | management-project-id                             | config-control |
+|                 File                 |              APIVersion              |          Kind          |                                 Name                                 |   Namespace    |
+|--------------------------------------|--------------------------------------|------------------------|----------------------------------------------------------------------|----------------|
+| namespaces/hierarchy.yaml            | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | hierarchy-sa                                                         | config-control |
+| namespaces/hierarchy.yaml            | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | hierarchy-sa-folderadmin-permissions                                 | config-control |
+| namespaces/hierarchy.yaml            | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | hierarchy-sa-workload-identity-binding                               | config-control |
+| namespaces/hierarchy.yaml            | v1                                   | Namespace              | hierarchy                                                            |                |
+| namespaces/hierarchy.yaml            | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com                    | hierarchy      |
+| namespaces/hierarchy.yaml            | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-hierarchy-resource-reference-from-projects                     | hierarchy      |
+| namespaces/hierarchy.yaml            | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-hierarchy-resource-reference-from-policies                     | hierarchy      |
+| namespaces/hierarchy.yaml            | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-hierarchy-resource-reference-from-config-control               | hierarchy      |
+| namespaces/hierarchy.yaml            | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-folders-resource-reference-to-logging                          | hierarchy      |
+| namespaces/logging.yaml              | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | logging-sa                                                           | config-control |
+| namespaces/logging.yaml              | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | logging-sa-logadmin-permissions                                      | config-control |
+| namespaces/logging.yaml              | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | logging-sa-bigqueryadmin-permissions                                 | config-control |
+| namespaces/logging.yaml              | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | logging-sa-workload-identity-binding                                 | config-control |
+| namespaces/logging.yaml              | v1                                   | Namespace              | logging                                                              |                |
+| namespaces/logging.yaml              | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com                    | logging        |
+| namespaces/logging.yaml              | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-logging-resource-reference-from-projects                       | logging        |
+| namespaces/management-namespace.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | config-control-sa-orgroleadmin-permissions                           | config-control |
+| namespaces/management-namespace.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | config-control-sa-management-project-editor-permissions              | config-control |
+| namespaces/management-namespace.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | config-control-sa-management-project-serviceaccountadmin-permissions | config-control |
+| namespaces/monitoring.yaml           | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | metrics-sa                                                           | config-control |
+| namespaces/monitoring.yaml           | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | metrics-writer-permissions                                           | config-control |
+| namespaces/monitoring.yaml           | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | metrics-sa-workload-identity-binding                                 | config-control |
+| namespaces/monitoring.yaml           | v1                                   | Namespace              | monitoring                                                           |                |
+| namespaces/monitoring.yaml           | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com                    | monitoring     |
+| namespaces/networking.yaml           | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | networking-sa                                                        | config-control |
+| namespaces/networking.yaml           | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | networking-sa-networkadmin-permissions                               | config-control |
+| namespaces/networking.yaml           | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | networking-sa-security-permissions                                   | config-control |
+| namespaces/networking.yaml           | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | networking-sa-dns-permissions                                        | config-control |
+| namespaces/networking.yaml           | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | networking-sa-service-control-permissions                            | config-control |
+| namespaces/networking.yaml           | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | networking-sa-xpnadmin-permissions                                   | config-control |
+| namespaces/networking.yaml           | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | networking-sa-workload-identity-binding                              | config-control |
+| namespaces/networking.yaml           | v1                                   | Namespace              | networking                                                           |                |
+| namespaces/networking.yaml           | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com                    | networking     |
+| namespaces/policies.yaml             | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | policies-sa                                                          | config-control |
+| namespaces/policies.yaml             | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | policies-sa-orgpolicyadmin-permissions                               | config-control |
+| namespaces/policies.yaml             | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | policies-sa-workload-identity-binding                                | config-control |
+| namespaces/policies.yaml             | v1                                   | Namespace              | policies                                                             |                |
+| namespaces/policies.yaml             | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com                    | policies       |
+| namespaces/projects.yaml             | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | projects-sa                                                          | config-control |
+| namespaces/projects.yaml             | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-projectiamadmin-permissions                              | config-control |
+| namespaces/projects.yaml             | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-projectcreator-permissions                               | config-control |
+| namespaces/projects.yaml             | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-projectmover-permissions                                 | config-control |
+| namespaces/projects.yaml             | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-projectdeleter-permissions                               | config-control |
+| namespaces/projects.yaml             | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-serviceusageadmin-permissions                            | config-control |
+| namespaces/projects.yaml             | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-billinguser-permissions                                  | config-control |
+| namespaces/projects.yaml             | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | projects-sa-workload-identity-binding                                | config-control |
+| namespaces/projects.yaml             | v1                                   | Namespace              | projects                                                             |                |
+| namespaces/projects.yaml             | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com                    | projects       |
+| namespaces/projects.yaml             | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-projects-resource-reference-from-logging                       | projects       |
+| namespaces/projects.yaml             | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-projects-resource-reference-from-networking                    | projects       |
+| namespaces/projects.yaml             | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-projects-resource-reference-from-policies                      | projects       |
+| services.yaml                        | blueprints.cloud.google.com/v1alpha1 | ProjectServiceSet      | management-project-id                                                | config-control |
 
 ## Resource References
 
@@ -99,7 +108,7 @@ This package has no sub-packages.
 
 1.  Move into the local package:
     ```shell
-    cd "./landing-zone/"
+    cd ".//solutions/landing-zone-v2/"
     ```
 
 1.  Edit the function config file(s):

--- a/solutions/landing-zone-v2/namespaces/monitoring.yaml
+++ b/solutions/landing-zone-v2/namespaces/monitoring.yaml
@@ -1,0 +1,82 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# GCP SA
+# AC-3(7) - Creates lower priv service account for Policy Controller metrics
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: metrics-sa
+  namespace: config-control # kpt-set: ${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  displayName: metrics-sa
+---
+# Grant GCP role Metrics Writer to Metrics SA on KCC Project
+# AC-3(7) - RBAC role to account with required permissions for Policy Controller metrics
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: metrics-writer-permissions
+  namespace: config-control # kpt-set: ${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: management-project-id # kpt-set: ${management-project-id}
+  role: roles/monitoring.metricWriter
+  member: "serviceAccount:metrics-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:metrics-sa@${management-project-id}.iam.gserviceaccount.com
+---
+# K8S SA
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata:
+  name: metrics-sa-workload-identity-binding
+  namespace: config-control # kpt-set: ${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    name: metrics-sa
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member: serviceAccount:management-project-id.svc.id.goog[gatekeeper-system/gatekeeper-admin] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[gatekeeper-system/gatekeeper-admin]
+---
+# K8S namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+---
+# Link GCP SA to K8S namespace
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: monitoring
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  googleServiceAccount: metrics-sa@management-project-id.iam.gserviceaccount.com # kpt-set: metrics-sa@${management-project-id}.iam.gserviceaccount.com


### PR DESCRIPTION
Closes #328  (take 3)

Since we are using GKE Workload Identity we must complete the following steps outlined in
[Implementing Policy Controller Metrics](https://cloud.google.com/anthos-config-management/docs/how-to/policy-controller-metrics) to implement Policy Controller Metrics and avoid numerous IAM errors on the Config Controller instance.

Includes:

Monitoring namespace
Service account for the Metric Writer permission (roles/monitoring.metricWriter)
Binding for workload identity (serviceAccount:management-project-id.svc.id.goog[gatekeeper-system/gatekeeper-admin])
The gatekeeper-admin service account will need to be annotated post-deployment using the following command:

kubectl annotate serviceaccount gatekeeper-admin
--namespace gatekeeper-system
iam.gke.io/gcp-service-account=[metrics-sa@management-project-id.iam.gserviceaccount.com](mailto:metrics-sa@management-project-id.iam.gserviceaccount.com)