### PR TITLE
feat: add client-landing-zone package

### DIFF
--- a/solutions/client-landing-zone/Kptfile
+++ b/solutions/client-landing-zone/Kptfile
@@ -1,0 +1,16 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: client-landing-zone
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    Landing zone v2 subpackage.
+    Depends on `client-setup`.
+
+    Package to create a client's folder hierarchy, logging resources and a network host project.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/client-landing-zone/README.md
+++ b/solutions/client-landing-zone/README.md
@@ -1,0 +1,143 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# client-landing-zone
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+Landing zone v2 subpackage.
+Depends on `client-setup`.
+
+Package to create a client's folder hierarchy, logging resources and a network host project.
+
+## Setters
+
+|                Name                |                    Value                    | Type  | Count |
+|------------------------------------|---------------------------------------------|-------|-------|
+| client-billing-id                  | AAAAAA-BBBBBB-CCCCCC                        | str   |     1 |
+| client-folderviewer                | group:client1@example.com                   | str   |     1 |
+| client-name                        | client1                                     | str   |    77 |
+| firewall-egress-allow-all-internal | [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16] | array |     1 |
+| host-project-id                    | net-host-project-12345                      | str   |    93 |
+| internet-nane1-protected-a-snet    | 10.1.64.0/21                                | str   |     1 |
+| internet-nane1-protected-b-snet    | 10.1.128.0/21                               | str   |     1 |
+| internet-nane1-unclassified-snet   | 10.1.0.0/21                                 | str   |     1 |
+| internet-nane2-protected-a-snet    | 10.1.72.0/21                                | str   |     1 |
+| internet-nane2-protected-b-snet    | 10.1.136.0/21                               | str   |     1 |
+| internet-nane2-unclassified-snet   | 10.1.8.0/21                                 | str   |     1 |
+| logging-project-id                 | logging-project-12345                       | str   |     2 |
+| retention-in-days                  |                                           1 | int   |     1 |
+| retention-locking-policy           | false                                       | bool  |     1 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|                                                                  File                                                                   |                  APIVersion                   |            Kind             |                               Name                               |       Namespace        |
+|-----------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|-----------------------------|------------------------------------------------------------------|------------------------|
+| client-folder/folder-iam.yaml                                                                                                           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember             | clients.client-name-client-folder-viewer-permissions             | client-name-hierarchy  |
+| client-folder/folder-sink.yaml                                                                                                          | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink              | platform-and-component-log-client-name-log-sink                  | logging                |
+| client-folder/standard/applications/folder.yaml                                                                                         | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard.applications                                            | client-name-hierarchy  |
+| client-folder/standard/applications/nonp/folder.yaml                                                                                    | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard.applications.nonp                                       | client-name-hierarchy  |
+| client-folder/standard/applications/pa/folder.yaml                                                                                      | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard.applications.pa                                         | client-name-hierarchy  |
+| client-folder/standard/applications/pb/folder.yaml                                                                                      | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard.applications.pb                                         | client-name-hierarchy  |
+| client-folder/standard/applications-infrastructure/folder.yaml                                                                          | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard.applications-infrastructure                             | client-name-hierarchy  |
+| client-folder/standard/applications-infrastructure/host-project/network/dnspolicy.yaml                                                  | dns.cnrm.cloud.google.com/v1beta1             | DNSPolicy                   | host-project-id-internet-logging-dnspolicy                       | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/firewall.yaml                                                   | compute.cnrm.cloud.google.com/v1beta1         | ComputeFirewall             | host-project-id-internet-egress-allow-all-internal-fwr           | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/firewall.yaml                                                   | compute.cnrm.cloud.google.com/v1beta1         | ComputeFirewall             | host-project-id-internet-default-egress-deny-fwr                 | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/dns.yaml                                        | dns.cnrm.cloud.google.com/v1beta1             | DNSManagedZone              | host-project-id-internet-googleapis-dns                          | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/dns.yaml                                        | dns.cnrm.cloud.google.com/v1beta1             | DNSRecordSet                | host-project-id-internet-googleapis-rset                         | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/dns.yaml                                        | dns.cnrm.cloud.google.com/v1beta1             | DNSRecordSet                | host-project-id-internet-googleapis-wildcard-rset                | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/dns.yaml                                        | dns.cnrm.cloud.google.com/v1beta1             | DNSManagedZone              | host-project-id-internet-gcrio-dns                               | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/dns.yaml                                        | dns.cnrm.cloud.google.com/v1beta1             | DNSRecordSet                | host-project-id-internet-gcrio-rset                              | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/dns.yaml                                        | dns.cnrm.cloud.google.com/v1beta1             | DNSRecordSet                | host-project-id-internet-gcrio-wildcard-rset                     | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/firewall.yaml                                   | compute.cnrm.cloud.google.com/v1beta1         | ComputeFirewall             | host-project-id-internet-egress-allow-psc-fwr                    | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/psc.yaml                                        | compute.cnrm.cloud.google.com/v1beta1         | ComputeAddress              | host-project-id-internet-psc-apis-ip                             | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/psc.yaml                                        | compute.cnrm.cloud.google.com/v1beta1         | ComputeForwardingRule       | host-project-id-internet-psc-apis-fw                             | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/subnet.yaml                                                     | compute.cnrm.cloud.google.com/v1beta1         | ComputeSubnetwork           | host-project-id-nane1-internet-unclassified-snet                 | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/subnet.yaml                                                     | compute.cnrm.cloud.google.com/v1beta1         | ComputeSubnetwork           | host-project-id-nane1-internet-protected-a-snet                  | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/subnet.yaml                                                     | compute.cnrm.cloud.google.com/v1beta1         | ComputeSubnetwork           | host-project-id-nane1-internet-protected-b-snet                  | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/subnet.yaml                                                     | compute.cnrm.cloud.google.com/v1beta1         | ComputeSubnetwork           | host-project-id-nane2-internet-unclassified-snet                 | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/subnet.yaml                                                     | compute.cnrm.cloud.google.com/v1beta1         | ComputeSubnetwork           | host-project-id-nane2-internet-protected-a-snet                  | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/subnet.yaml                                                     | compute.cnrm.cloud.google.com/v1beta1         | ComputeSubnetwork           | host-project-id-nane2-internet-protected-b-snet                  | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/network/vpc.yaml                                                        | compute.cnrm.cloud.google.com/v1beta1         | ComputeNetwork              | host-project-id-global-internet-vpc                              | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/org-policies/exceptions/gcp-resource-locations-except-host-project.yaml | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy       | gcp-restrict-resource-locations-except-host-project-id           | policies               |
+| client-folder/standard/applications-infrastructure/host-project/project.yaml                                                            | resourcemanager.cnrm.cloud.google.com/v1beta1 | Project                     | host-project-id                                                  | client-name-projects   |
+| client-folder/standard/applications-infrastructure/host-project/project.yaml                                                            | compute.cnrm.cloud.google.com/v1beta1         | ComputeSharedVPCHostProject | host-project-id-hostvpc                                          | client-name-networking |
+| client-folder/standard/applications-infrastructure/host-project/services.yaml                                                           | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                     | host-project-id-compute                                          | client-name-projects   |
+| client-folder/standard/applications-infrastructure/host-project/services.yaml                                                           | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                     | host-project-id-dns                                              | client-name-projects   |
+| client-folder/standard/applications-infrastructure/host-project/services.yaml                                                           | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                     | host-project-id-servicedirectory                                 | client-name-projects   |
+| client-folder/standard/applications-infrastructure/host-project/services.yaml                                                           | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                     | host-project-id-container                                        | client-name-projects   |
+| client-folder/standard/applications-infrastructure/nonp/folder.yaml                                                                     | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard.applications-infrastructure.nonp                        | client-name-hierarchy  |
+| client-folder/standard/applications-infrastructure/pa/folder.yaml                                                                       | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard.applications-infrastructure.pa                          | client-name-hierarchy  |
+| client-folder/standard/applications-infrastructure/pb/folder.yaml                                                                       | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard.applications-infrastructure.pb                          | client-name-hierarchy  |
+| client-folder/standard/auto/folder.yaml                                                                                                 | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard.auto                                                    | client-name-hierarchy  |
+| client-folder/standard/auto/nonp/folder.yaml                                                                                            | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard.auto.nonp                                               | client-name-hierarchy  |
+| client-folder/standard/auto/pa/folder.yaml                                                                                              | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard.auto.pa                                                 | client-name-hierarchy  |
+| client-folder/standard/auto/pb/folder.yaml                                                                                              | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard.auto.pb                                                 | client-name-hierarchy  |
+| client-folder/standard/folder.yaml                                                                                                      | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                      | standard                                                         | client-name-hierarchy  |
+| logging-project/cloud-logging-bucket.yaml                                                                                               | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogBucket            | platform-and-component-client-name-log-bucket                    | logging                |
+| logging-project/project-iam.yaml                                                                                                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy            | platform-and-component-log-client-name-bucket-writer-permissions | projects               |
+
+## Resource References
+
+- [ComputeAddress](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeaddress)
+- [ComputeFirewall](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computefirewall)
+- [ComputeForwardingRule](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeforwardingrule)
+- [ComputeNetwork](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computenetwork)
+- [ComputeSharedVPCHostProject](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computesharedvpchostproject)
+- [ComputeSubnetwork](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computesubnetwork)
+- [DNSManagedZone](https://cloud.google.com/config-connector/docs/reference/resource-docs/dns/dnsmanagedzone)
+- [DNSPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/dns/dnspolicy)
+- [DNSRecordSet](https://cloud.google.com/config-connector/docs/reference/resource-docs/dns/dnsrecordset)
+- [Folder](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/folder)
+- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [LoggingLogBucket](https://cloud.google.com/config-connector/docs/reference/resource-docs/logging/logginglogbucket)
+- [LoggingLogSink](https://cloud.google.com/config-connector/docs/reference/resource-docs/logging/logginglogsink)
+- [Project](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/project)
+- [ResourceManagerPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/resourcemanagerpolicy)
+- [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/client-landing-zone@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd ".//solutions/client-landing-zone/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/client-landing-zone/client-folder/folder-iam.yaml
+++ b/solutions/client-landing-zone/client-folder/folder-iam.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Grant GCP role Folder Viewer on client's folder to client's user group
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: clients.client-name-client-folder-viewer-permissions # kpt-set: clients.${client-name}-client-folder-viewer-permissions
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    name: clients.client-name # kpt-set: clients.${client-name}
+    namespace: hierarchy
+  role: roles/resourcemanager.folderViewer
+  member: client-name-folderviewer # kpt-set: ${client-folderviewer}

--- a/solutions/client-landing-zone/client-folder/folder-sink.yaml
+++ b/solutions/client-landing-zone/client-folder/folder-sink.yaml
@@ -1,0 +1,56 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# TODO: investigate using client ns, move functionality to client-setup and/or create new client logging project
+# Folder sink for Platform and Component logs of Client Resources
+# Destination: cloud logging bucket inside logging project
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogSink
+metadata:
+  name: platform-and-component-log-client-name-log-sink # kpt-set: platform-and-component-log-${client-name}-log-sink
+  namespace: logging
+  annotations:
+    config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/platform-and-component-client-name-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/platform-and-component-${client-name}-log-bucket
+spec:
+  folderRef:
+    name: clients.client-name # kpt-set: clients.${client-name}
+    namespace: hierarchy
+  includeChildren: true
+  destination:
+    loggingLogBucketRef:
+      # destination.loggingLogBucketRef
+      # Only `external` field is supported to configure the reference.
+      external: platform-and-component-client-name-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/platform-and-component-${client-name}-log-bucket
+  description: Folder sink for client-name Platform and Component logs # kpt-set: Folder sink for ${client-name} Platform and Component logs
+  # AU-2, AU-12(A), AU-12(C)
+  # Includes the following types of logs:
+  # Cloud DNS, Cloud NAT, Firewall Rules, VPC Flow, and HTTP(S) Load Balancer
+  # Logs for such resources must be enabled on the respective resource as they are not enabled by default.
+  filter: |-
+    LOG_ID("dns.googleapis.com/dns_queries")
+    OR (LOG_ID("compute.googleapis.com/nat_flows") AND resource.type="nat_gateway")
+    OR (LOG_ID("compute.googleapis.com/firewall") AND resource.type="gce_subnetwork")
+    OR (LOG_ID("compute.googleapis.com/vpc_flows") AND resource.type="gce_subnetwork")
+    OR (LOG_ID("requests") AND resource.type="http_load_balancer")
+  # Excludes all Security logs: Cloud Audit, Access Transparency, and Data Access Logs
+  exclusions:
+    - description: Exclude Security logs
+      disabled: false
+      filter: |-
+        LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("externalaudit.googleapis.com/activity")
+        OR LOG_ID("cloudaudit.googleapis.com/data_access") OR LOG_ID("externalaudit.googleapis.com/data_access")
+        OR LOG_ID("cloudaudit.googleapis.com/system_event") OR LOG_ID("externalaudit.googleapis.com/system_event")
+        OR LOG_ID("cloudaudit.googleapis.com/policy") OR LOG_ID("externalaudit.googleapis.com/policy")
+        OR LOG_ID("cloudaudit.googleapis.com/access_transparency") OR LOG_ID("externalaudit.googleapis.com/access_transparency")
+      name: exclude-security-logs

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard.applications-infrastructure
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: applications-infrastructure
+  folderRef:
+    name: standard

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/dnspolicy.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/dnspolicy.yaml
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Enable DNS logging
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSPolicy
+metadata:
+  name: host-project-id-internet-logging-dnspolicy # kpt-set: ${host-project-id}-internet-logging-dnspolicy
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  resourceID: internet-logging-dnspolicy
+  description: "Enable DNS logging"
+  enableLogging: true
+  networks:
+    - networkRef:
+        name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/firewall.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/firewall.yaml
@@ -1,0 +1,61 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# egress allow all internal
+# AC-4, AC-4(21), SC-7(C), SC-7(5)
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeFirewall
+metadata:
+  name: host-project-id-internet-egress-allow-all-internal-fwr # kpt-set: ${host-project-id}-internet-allow-all-internal-fwr
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  resourceID: internet-egress-allow-all-internal-fwr
+  description: "egress allow all internal"
+  direction: EGRESS
+  priority: 5000
+  allow:
+    - protocol: all
+  destinationRanges: # kpt-set: ${firewall-egress-allow-all-internal}
+    - 10.0.0.0/8
+  networkRef:
+    name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc
+---
+# Default egress deny all
+# AC-4, AC-4(21), SC-7(C), SC-7(5)
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeFirewall
+metadata:
+  name: host-project-id-internet-default-egress-deny-fwr # kpt-set: ${host-project-id}-internet-default-egress-deny-fwr
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  resourceID: internet-default-egress-deny-fwr
+  description: "Default egress deny all"
+  direction: EGRESS
+  priority: 65535
+  deny:
+    - protocol: all
+  sourceRanges:
+    - 10.0.0.0/8
+  destinationRanges:
+    - 0.0.0.0/0
+  networkRef:
+    name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/dns.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/dns.yaml
@@ -1,0 +1,129 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Private DNS zone for googleapis.com
+# SC-22
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSManagedZone
+metadata:
+  name: host-project-id-internet-googleapis-dns # kpt-set: ${host-project-id}-internet-googleapis-dns
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  description: "Private DNS zone for googleapis.com"
+  resourceID: internet-googleapis-dns
+  dnsName: "googleapis.com."
+  visibility: private
+  privateVisibilityConfig:
+    networks:
+      - networkRef:
+          name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc
+---
+# Record Set for googleapis.com in googleapis.com DNS zone
+# SC-22
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: host-project-id-internet-googleapis-rset # kpt-set: ${host-project-id}-internet-googleapis-rset
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  name: "googleapis.com."
+  type: "A"
+  ttl: 300
+  managedZoneRef:
+    name: host-project-id-internet-googleapis-dns # kpt-set: ${host-project-id}-internet-googleapis-dns
+  rrdatas:
+    - "10.255.255.254"
+---
+# Record Set for wildcard in googleapis.com DNS zone
+# SC-22
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: host-project-id-internet-googleapis-wildcard-rset # kpt-set: ${host-project-id}-internet-googleapis-wildcard-rset
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  name: "*.googleapis.com."
+  type: "CNAME"
+  ttl: 300
+  managedZoneRef:
+    name: host-project-id-internet-googleapis-dns # kpt-set: ${host-project-id}-internet-googleapis-dns
+  rrdatas:
+    - "googleapis.com."
+---
+# Private DNS zone for gcr.io
+# SC-22
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSManagedZone
+metadata:
+  name: host-project-id-internet-gcrio-dns # kpt-set: ${host-project-id}-internet-gcrio-dns
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  description: "Private DNS zone for gcr.io"
+  resourceID: internet-gcrio-dns
+  dnsName: "gcr.io."
+  visibility: private
+  privateVisibilityConfig:
+    networks:
+      - networkRef:
+          name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc
+---
+# Record Set for gcr.io in gcr.io DNS zone
+# SC-22
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: host-project-id-internet-gcrio-rset # kpt-set: ${host-project-id}-internet-gcrio-rset
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  name: "gcr.io."
+  type: "A"
+  ttl: 300
+  managedZoneRef:
+    name: host-project-id-internet-gcrio-dns # kpt-set: ${host-project-id}-internet-gcrio-dns
+  rrdatas:
+    - "10.255.255.254"
+---
+# Record Set for wildcard in gcr.io DNS zone
+# SC-22
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: host-project-id-internet-gcrio-wildcard-rset # kpt-set: ${host-project-id}-internet-gcrio-wildcard-record-set
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  name: "*.gcr.io."
+  type: "CNAME"
+  ttl: 300
+  managedZoneRef:
+    name: host-project-id-internet-gcrio-dns # kpt-set: ${host-project-id}-internet-gcrio-dns
+  rrdatas:
+    - "gcr.io."

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/firewall.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/firewall.yaml
@@ -1,0 +1,35 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Egress allow traffic to Private Service Connect endpoint for Google API access
+# AC-4, AC-4(21), SC-7(C), SC-7(5)
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeFirewall
+metadata:
+  name: host-project-id-internet-egress-allow-psc-fwr # kpt-set: ${host-project-id}-internet-egress-allow-psc-fwr
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  resourceID: internet-egress-allow-psc-fwr
+  description: "Egress allow traffic to Private Service Connect endpoint for Google API access"
+  direction: EGRESS
+  priority: 1000
+  allow:
+    - protocol: all
+  destinationRanges:
+    - 10.255.255.254/32
+  networkRef:
+    name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/psc.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/psc.yaml
@@ -1,0 +1,64 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# IP address for Private Service Connect endpoint for Google API
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
+metadata:
+  name: host-project-id-internet-psc-apis-ip # kpt-set: ${host-project-id}-internet-psc-apis-ip
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  resourceID: internet-psc-apis-ip
+  addressType: INTERNAL
+  description: IP address for Private Service Connect endpoint for Google APIs
+  location: global
+  ipVersion: IPV4
+  purpose: PRIVATE_SERVICE_CONNECT
+  address: 10.255.255.254
+  networkRef:
+    name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc
+    namespace: client-name-networking # kpt-set: ${client-name}-networking
+---
+# Forwarding rule for Private Service Connect endpoint for Google API
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeForwardingRule
+metadata:
+  name: host-project-id-internet-psc-apis-fw # kpt-set: ${host-project-id}-internet-psc-apis-fw
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  # TODO: bug: errors when defining description field
+  # description: "Private Service Connect endpoint for Google API"
+  ipAddress:
+    addressRef:
+      name: host-project-id-internet-psc-apis-ip # kpt-set: ${host-project-id}-internet-psc-apis-ip
+  # loadBalancingScheme must be disabled using loadBalancingScheme: ""
+  # googleapi: Error 400: Invalid value for field 'resource.loadBalancingScheme': 'EXTERNAL'
+  # Invalid field set in Private Service Connect Forwarding Rule. This field should not be set., invalid
+  loadBalancingScheme: ""
+  location: global
+  # TODO: bug: missing service directory registration with a specific region to avoid default us-central1 region.
+  # https://github.com/GoogleCloudPlatform/magic-modules/pull/7480
+  networkRef:
+    external: https://www.googleapis.com/compute/beta/projects/project-id/global/networks/global-internet-vpc # kpt-set: https://www.googleapis.com/compute/beta/projects/${host-project-id}/global/networks/global-internet-vpc
+  # The forwarding rule name for PSC Google APIs must be an 1-20 characters string with lowercase letters and numbers and must start with a letter
+  resourceID: internetpscapisfw
+  target:
+    targetHTTPProxyRef:
+      external: all-apis

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/subnet.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/subnet.yaml
@@ -1,0 +1,155 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# All subnets have :
+# - logging enabled for flow logs https://cloud.google.com/vpc/docs/using-flow-logs
+# - private google access enabled https://cloud.google.com/vpc/docs/private-google-access
+#########
+# Subnet unclassified northamerica-northeast1
+# AC-4, AC-4(21)
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: host-project-id-nane1-internet-unclassified-snet # kpt-set: ${host-project-id}-nane1-internet-unclassified-snet
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  resourceID: nane1-internet-unclassified-snet
+  ipCidrRange: 10.1.1.0/24 # kpt-set: ${internet-nane1-unclassified-snet}
+  region: northamerica-northeast1
+  description: northamerica-northeast1 unclassified subnet
+  privateIpGoogleAccess: true
+  networkRef:
+    name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc
+  logConfig:
+    aggregationInterval: INTERVAL_5_SEC
+    flowSampling: 0.5
+    metadata: INCLUDE_ALL_METADATA
+---
+# Subnet protected-a northamerica-northeast1
+# AC-4, AC-4(21)
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: host-project-id-nane1-internet-protected-a-snet # kpt-set: ${host-project-id}-nane1-internet-protected-a-snet
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  resourceID: nane1-internet-protected-a-snet
+  ipCidrRange: 10.1.2.0/24 # kpt-set: ${internet-nane1-protected-a-snet}
+  region: northamerica-northeast1
+  description: northamerica-northeast1 protected-a subnet
+  privateIpGoogleAccess: true
+  networkRef:
+    name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc
+  logConfig:
+    aggregationInterval: INTERVAL_5_SEC
+    flowSampling: 0.5
+    metadata: INCLUDE_ALL_METADATA
+---
+# Subnet protected-b northamerica-northeast1
+# AC-4, AC-4(21)
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: host-project-id-nane1-internet-protected-b-snet # kpt-set: ${host-project-id}-nane1-internet-protected-b-snet
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  resourceID: nane1-internet-protected-b-snet
+  ipCidrRange: 10.1.3.0/24 # kpt-set: ${internet-nane1-protected-b-snet}
+  region: northamerica-northeast1
+  description: northamerica-northeast1 protected-b subnet
+  privateIpGoogleAccess: true
+  networkRef:
+    name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc
+  logConfig:
+    aggregationInterval: INTERVAL_5_SEC
+    flowSampling: 0.5
+    metadata: INCLUDE_ALL_METADATA
+---
+# Subnet unclassified northamerica-northeast2
+# AC-4, AC-4(21)
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: host-project-id-nane2-internet-unclassified-snet # kpt-set: ${host-project-id}-nane2-internet-unclassified-snet
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  resourceID: nane2-internet-unclassified-snet
+  ipCidrRange: 10.2.1.0/24 # kpt-set: ${internet-nane2-unclassified-snet}
+  region: northamerica-northeast2
+  description: northamerica-northeast2 unclassified subnet
+  privateIpGoogleAccess: true
+  networkRef:
+    name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc
+  logConfig:
+    aggregationInterval: INTERVAL_5_SEC
+    flowSampling: 0.5
+    metadata: INCLUDE_ALL_METADATA
+---
+# Subnet protected-a northamerica-northeast2
+# AC-4, AC-4(21)
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: host-project-id-nane2-internet-protected-a-snet # kpt-set: ${host-project-id}-nane2-internet-protected-a-snet
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  resourceID: nane2-internet-protected-a-snet
+  ipCidrRange: 10.2.2.0/24 # kpt-set: ${internet-nane2-protected-a-snet}
+  region: northamerica-northeast2
+  description: northamerica-northeast2 protected-a subnet
+  privateIpGoogleAccess: true
+  networkRef:
+    name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc
+  logConfig:
+    aggregationInterval: INTERVAL_5_SEC
+    flowSampling: 0.5
+    metadata: INCLUDE_ALL_METADATA
+---
+# Subnet protected-b northamerica-northeast2
+# AC-4, AC-4(21)
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: host-project-id-nane2-internet-protected-b-snet # kpt-set: ${host-project-id}-nane2-internet-protected-b-snet
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-internet-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-internet-vpc
+spec:
+  resourceID: nane2-internet-protected-b-snet
+  ipCidrRange: 10.2.3.0/24 # kpt-set: ${internet-nane2-protected-b-snet}
+  region: northamerica-northeast2
+  description: northamerica-northeast2 protected-b subnet
+  privateIpGoogleAccess: true
+  networkRef:
+    name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc
+  logConfig:
+    aggregationInterval: INTERVAL_5_SEC
+    flowSampling: 0.5
+    metadata: INCLUDE_ALL_METADATA

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/vpc.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/vpc.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# VPC
+# AC-4, AC-4(21)
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: host-project-id-global-internet-vpc # kpt-set: ${host-project-id}-global-internet-vpc
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: serviceusage.cnrm.cloud.google.com/namespaces/client-name-projects/Service/host-project-id-compute # kpt-set: serviceusage.cnrm.cloud.google.com/namespaces/${client-name}-projects/Service/${host-project-id}-compute
+spec:
+  resourceID: global-internet-vpc
+  description: VPC for internet facing application
+  routingMode: GLOBAL
+  autoCreateSubnetworks: false # SC-7
+  deleteDefaultRoutesOnCreate: true # AC-4, SC-7(5)

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/org-policies/exceptions/gcp-resource-locations-except-host-project.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/org-policies/exceptions/gcp-resource-locations-except-host-project.yaml
@@ -1,0 +1,48 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+#
+# GCP Organization Policies
+# Org policies that correspond with a Guardrail will contain a label indicating what Guardrails it helps in enforcing
+# https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints
+#
+# Constraint: constraints/gcp.resourceLocations
+#
+# This list constraint defines the set of locations where location-based GCP resources can be created.
+#
+# This exception is to allow the us-central1 location until the issue below is resolved with the config connector forwardingRule resource.
+# This resource is used by the PSC for googleapis.
+# https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/754
+#
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: ResourceManagerPolicy
+metadata:
+  name: gcp-restrict-resource-locations-except-host-project-id # kpt-set: gcp-restrict-resource-locations-except-${host-project-id}
+  namespace: policies
+  labels:
+    guardrail: "true"
+    guardrails-enforced: guardrail-05
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/host-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${host-project-id}
+spec:
+  constraint: "constraints/gcp.resourceLocations"
+  listPolicy:
+    allow:
+      values:
+        - "in:northamerica-northeast1-locations"
+        - "in:northamerica-northeast2-locations"
+        - "in:us-central1-locations"
+  projectRef:
+    external: "0000000000" # kpt-set: ${host-project-id}

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/project.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/project.yaml
@@ -1,0 +1,40 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Project
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  name: host-project-id # kpt-set: ${host-project-id}
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/auto-create-network: "false"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-hierarchy/Folder/standard.applications-infrastructure # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-hierarchy/Folder/standard.applications-infrastructure
+spec:
+  name: host-project-id # kpt-set: ${host-project-id}
+  billingAccountRef:
+    external: "AAAAAA-BBBBBB-CCCCCC" # kpt-set: ${client-billing-id}
+  folderRef:
+    name: standard.applications-infrastructure
+    namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+---
+# Activate Host Project
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSharedVPCHostProject
+metadata:
+  name: host-project-id-hostvpc # kpt-set: ${host-project-id}-host-vpc
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: serviceusage.cnrm.cloud.google.com/namespaces/client-name-projects/Service/host-project-id-compute # kpt-set: serviceusage.cnrm.cloud.google.com/namespaces/${client-name}-projects/Service/${host-project-id}-compute

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/securitycontrols.md
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/securitycontrols.md
@@ -1,0 +1,39 @@
+# Security Controls
+
+## Technical Controls - P1
+
+### AC-4
+
+- Deny all egress to spoke's IP, allow only connectivity to private GCP API endpoints. Hub will control traffic to other networks
+- Separate subnets to segregate traffic
+- Routing traffic through hub VPC
+- VPC restricts subnets to Canadian region locations
+
+### AU-3
+
+- Enables DNS audit logging which is sent into the logging stream being captured by the logging project
+
+### SC-7(C), SC-7(5)
+
+- Deny all egress to spoke's IP, allow only connectivity to private GCP API endpoints. Hub will control traffic to other networks
+
+## Technical Controls - P2
+
+### AU-3(1)
+
+- Enables DNS audit logging which is sent into the logging stream being captured by the logging project
+
+## Technical Controls - P3
+
+### SC-22
+
+- Implement internal/external name resolution segregation, resolving GCP API queries to private endpoints. Uses GCP DNS functionality that is fault-tolerant
+
+## Technical Controls - Undefined Priority
+
+AC-4(21)
+
+- Deny all egress to spoke's IP, allow only connectivity to private GCP API endpoints. Hub will control traffic to other networks
+- Separate subnets to segregate traffic
+- Routing traffic through hub VPC
+- VPC restricts subnets to Canadian region locations

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/services.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/services.yaml
@@ -1,0 +1,70 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Compute API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: host-project-id-compute # kpt-set: ${host-project-id}-compute
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${host-project-id}
+spec:
+  resourceID: compute.googleapis.com
+---
+# DNS API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: host-project-id-dns # kpt-set: ${host-project-id}-dns
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${host-project-id}
+spec:
+  resourceID: dns.googleapis.com
+---
+# Service Directory API
+# Required for Private Service Connect
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: host-project-id-servicedirectory # kpt-set: ${host-project-id}-servicedirectory
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${host-project-id}
+spec:
+  resourceID: servicedirectory.googleapis.com
+---
+# Container API
+# Required for Allowing GKE clusters to be deployed in service projects
+# Enabling the API in a project creates a GKE service account for the project.
+# https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: host-project-id-container # kpt-set: ${host-project-id}-container
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${host-project-id}
+spec:
+  resourceID: container.googleapis.com

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/nonp/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/nonp/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard.applications-infrastructure.nonp
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: nonp
+  folderRef:
+    name: standard.applications-infrastructure

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/pa/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/pa/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard.applications-infrastructure.pa
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: pa
+  folderRef:
+    name: standard.applications-infrastructure

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/pb/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/pb/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard.applications-infrastructure.pb
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: pb
+  folderRef:
+    name: standard.applications-infrastructure

--- a/solutions/client-landing-zone/client-folder/standard/applications/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard.applications
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: applications
+  folderRef:
+    name: standard

--- a/solutions/client-landing-zone/client-folder/standard/applications/nonp/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications/nonp/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard.applications.nonp
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: nonp
+  folderRef:
+    name: standard.applications

--- a/solutions/client-landing-zone/client-folder/standard/applications/pa/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications/pa/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard.applications.pa
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: pa
+  folderRef:
+    name: standard.applications

--- a/solutions/client-landing-zone/client-folder/standard/applications/pb/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications/pb/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard.applications.pb
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: pb
+  folderRef:
+    name: standard.applications

--- a/solutions/client-landing-zone/client-folder/standard/auto/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/auto/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard.auto
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: auto
+  folderRef:
+    name: standard

--- a/solutions/client-landing-zone/client-folder/standard/auto/nonp/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/auto/nonp/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard.auto.nonp
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: nonp
+  folderRef:
+    name: standard.auto

--- a/solutions/client-landing-zone/client-folder/standard/auto/pa/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/auto/pa/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard.auto.pa
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: pa
+  folderRef:
+    name: standard.auto

--- a/solutions/client-landing-zone/client-folder/standard/auto/pb/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/auto/pb/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard.auto.pb
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: pb
+  folderRef:
+    name: standard.auto

--- a/solutions/client-landing-zone/client-folder/standard/folder.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/folder.yaml
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: standard
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+spec:
+  displayName: standard
+  folderRef:
+    name: clients.client-name # kpt-set: clients.${client-name}
+    namespace: hierarchy

--- a/solutions/client-landing-zone/logging-project/cloud-logging-bucket.yaml
+++ b/solutions/client-landing-zone/logging-project/cloud-logging-bucket.yaml
@@ -1,0 +1,33 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# TODO: investigate using client ns, move functionality to client-setup and/or create new client logging project
+# Cloud Logging bucket for client Platform and Component logs
+# Logs are routed using a log sink to a central logging project into a dedicated log bucket
+# AU-4(1), AU-9(2) - Log buckets are created in a logging project, isolating them from the source of the log entries in other projects
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogBucket
+metadata:
+  name: platform-and-component-client-name-log-bucket # kpt-set: platform-and-component-${client-name}-log-bucket
+  namespace: logging
+spec:
+  projectRef:
+    name: logging-project-id # kpt-set: ${logging-project-id}
+    namespace: projects
+  location: northamerica-northeast1
+  description: Cloud Logging bucket for client-name Platform and Component logs # kpt-set: Cloud Logging bucket for ${client-name} Platform and Component logs
+  # Implement retention policy and retention locking policy
+  # AU-9, AU-11 - RetentionDays sets the policy where existing log content cannot be changed/deleted for the specificied number of days (from setters.yaml), locked setting means policy cannot be changed, ensuring immutability.
+  locked: false # kpt-set: ${retention-locking-policy}
+  retentionDays: 1 # kpt-set: ${retention-in-days}

--- a/solutions/client-landing-zone/logging-project/project-iam.yaml
+++ b/solutions/client-landing-zone/logging-project/project-iam.yaml
@@ -1,0 +1,35 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# TODO: investigate using client ns, move functionality to client-setup and/or create new client logging project
+# Logs Bucket writer IAM permissions
+# Binds the generated Writer identity from the LoggingLogSink to the logging project
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata:
+  name: platform-and-component-log-client-name-bucket-writer-permissions # kpt-set: platform-and-component-log-${client-name}-bucket-writer-permissions
+  namespace: projects
+spec:
+  resourceRef:
+    kind: Project
+    name: logging-project-id # kpt-set: ${logging-project-id}
+    namespace: projects
+  # AC-3(7) - Write access to the logging bucket is limited by IAM to just the identity of the log sink configured to send logs to the bucket (set at the logging project level)
+  bindings:
+    - role: roles/logging.bucketWriter
+      members:
+        - memberFrom:
+            logSinkRef:
+              name: platform-and-component-log-client-name-sink # kpt-set: platform-and-component-log-${client-name}-log-sink
+              namespace: logging

--- a/solutions/client-landing-zone/logging-project/securitycontrols.md
+++ b/solutions/client-landing-zone/logging-project/securitycontrols.md
@@ -1,0 +1,47 @@
+# Security Controls
+
+## AC-3(7) ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+
+AC-3(7) – Write access to the logs is constrained by IAM permissions to just the log sinks.
+Added this control to project-iam.yaml in bindings where bucketWriter role is assigned.
+
+## AU-2 AUDITABLE EVENTS
+
+AU-2 – Event families being audited are set here. Added this control to folder-sink.yaml immediately
+preceeding the filter including/exluding various log types
+
+Ops Note: This is an org control so the AU-2 tagging in the code is there to support the narrative Ops
+will write to demonstrate the org requirements
+
+## AU-4(1) AUDIT STORAGE CAPACITY | TRANSFER TO ALTERNATE STORAGE
+
+AU-4(1) – Logs are being sent to a logging project which is separate from the projects
+performing actions which generate log entries. Added to the cloud-logging-buckets.yaml
+where separate logging project is selected as target.
+
+## AU-8 TIME STAMPS
+
+AU-8 – Time stamps for audit records use internal Google time which is recorded in
+RFC3339 UTC format in log entries (see GCP documentation for LogEntry object, timestamp field)
+
+## AU-9 PROTECTION OF AUDIT INFORMATION
+
+AU-9 – Retention policies and policy locks are implemented so log contents is immutable. Added to
+cloud-logging-buckets.yaml prior to locked and retentionDays entrie. Also added to setters.yaml
+as previous entries are set from here.
+
+## AU-9(2) PROTECTION OF AUDIT INFORMATION | AUDIT BACKUP ON SEPARATE PHYSICAL SYSTEMS / COMPONENTS
+
+AU-9(2) – Logs sent to separate project, same response as AU-4(1)
+
+## AU-11 AUDIT RECORD RETENTION
+
+AU-11 – Audit log retention, same response as AU-9
+
+## AU-12(A) AUDIT GENERATION
+
+Same as AU-2 (this control is the implementation of AU-2)
+
+## AU-12(C) AUDIT GENERATION
+
+Same as AU-2 (this control is the implementation of AU-2)

--- a/solutions/client-landing-zone/setters.yaml
+++ b/solutions/client-landing-zone/setters.yaml
@@ -1,0 +1,97 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  # Project IDs must follow the rules below, additionally,
+  # if a gatekeeper policy is used to enforce specific naming conventions, refer to its documentation.
+  #   - All IDs should be universally unique.
+  #   - Must be 6 to 30 characters in length.
+  #   - Can only contain lowercase letters, numbers, and hyphens.
+  #   - Must start with a letter.
+  #   - Cannot end with a hyphen.
+  #   - Cannot be in use or previously used; this includes deleted projects.
+  #   - Cannot contain restricted strings, such as google and ssl.
+  #
+  ##########################
+  # Client
+  ##########################
+  #
+  # Name for the client, lowercase only
+  client-name: 'client1'
+  # Billing Account ID to be associated with projects
+  client-billing-id: "AAAAAA-BBBBBB-CCCCCC"
+  # group to grant viewer permission on client folder
+  client-folderviewer: 'group:client1@example.com'
+  #
+  ##########################
+  # Logging
+  ##########################
+  #
+  # logging project id created in core-landing-zone
+  logging-project-id: logging-project-12345
+  #
+  # LoggingLogBucket retention settings
+  # Set the number of days to retain logs in Cloud Logging buckets
+  # Set the lock mechanism on the bucket to: true or false
+  # After a retention policy is locked (true), you can't delete the bucket until every log in the bucket has fulfilled the bucket's retention period
+  # AU-9 PROTECTION OF AUDIT INFORMATION
+  # AU-11 AUDIT RECORD RETENTION
+  # The values below must be modified to locked: true and retentionDays: 365 in a Production setting to implement above mentioned security controls.
+  retention-locking-policy: "false"
+  retention-in-days: "1"
+  #
+  ##########################
+  # Network Host Project (standard)
+  ##########################
+  #
+  # the network host project id that will be created
+  host-project-id: net-host-project-12345
+  #
+  # assuming following ip space
+  # unclassified: 10.0.0.0/13
+  # protected a: 10.8.0.0/13
+  # protected b: 10.16.0.0/13
+  # standard VPC
+  # Subnet IP range for unclassified in northamerica-northeast1
+  internet-nane1-unclassified-snet: 10.1.0.0/21
+  # Subnet IP range for unclassified in northamerica-northeast2
+  internet-nane2-unclassified-snet: 10.1.8.0/21
+  # Subnet IP range for protected-a in northamerica-northeast1
+  internet-nane1-protected-a-snet: 10.1.64.0/21
+  # Subnet IP range for protected-a in northamerica-northeast2
+  internet-nane2-protected-a-snet: 10.1.72.0/21
+  # Subnet IP range for protected-b in northamerica-northeast1
+  internet-nane1-protected-b-snet: 10.1.128.0/21
+  # Subnet IP range for protected-b in northamerica-northeast2
+  internet-nane2-protected-b-snet: 10.1.136.0/21
+  # Destination ranges for the egress allow all internal firewall rule
+  firewall-egress-allow-all-internal: |
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
+  #
+  ##########################
+  # End of Configurations
+  ##########################


### PR DESCRIPTION
new package for issue #370
(additional PRs will be created for other packages and to update documentation)

**`solutions/client-landing-zone`**
- includes / deprecates packages:
    - solutions/hierarchy/client-env
    - solutions/logging/client-env
- adds features:
    - client shared vpc host project
- depends on:
    - solutions/client-setup

