### PR TITLE
feat: add client-project-setup package

### DIFF
--- a/solutions/client-project-setup/Kptfile
+++ b/solutions/client-project-setup/Kptfile
@@ -1,0 +1,16 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: client-project-setup
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    Landing zone v2 subpackage.
+    Depends on `client-landing-zone`.
+
+    Package to create a client's project, 2 project scoped namespaces for its resources and a root sync.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/client-project-setup/README.md
+++ b/solutions/client-project-setup/README.md
@@ -1,0 +1,121 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# client-project-setup
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+Landing zone v2 subpackage.
+Depends on `client-landing-zone`.
+
+Package to create a client's project, 2 project scoped namespaces for its resources and a root sync.
+
+## Setters
+
+|             Name             |              Value              | Type | Count |
+|------------------------------|---------------------------------|------|-------|
+| client-management-project-id | client-management-project-12345 | str  |     1 |
+| client-name                  | client1                         | str  |    51 |
+| host-project-id              | net-host-project-12345          | str  |     7 |
+| management-namespace         | config-control                  | str  |     8 |
+| management-project-id        | management-project-12345        | str  |     2 |
+| org-id                       |                      0000000000 | str  |     2 |
+| project-billing-id           | AAAAAA-BBBBBB-CCCCCC            | str  |     1 |
+| project-id                   | client-project-12345            | str  |    91 |
+| project-parent-folder        | project-parent-folder           | str  |     2 |
+| repo-branch                  | main                            | str  |     1 |
+| repo-dir                     | csync/deploy/env                | str  |     1 |
+| repo-url                     | git-repo-to-observe             | str  |     1 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|               File               |                  APIVersion                   |              Kind              |                                    Name                                     |         Namespace          |
+|----------------------------------|-----------------------------------------------|--------------------------------|-----------------------------------------------------------------------------|----------------------------|
+| namespaces/project-id-tier3.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount              | project-id-tier3-sa                                                         | client-name-config-control |
+| namespaces/project-id-tier3.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier3-sa-serviceaccountadmin-project-id-permissions              | client-name-projects       |
+| namespaces/project-id-tier3.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier3-sa-securityadmin-project-id-permissions                    | client-name-projects       |
+| namespaces/project-id-tier3.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier3-sa-tier3-firewallrule-admin-host-project-id-permissions    | client-name-projects       |
+| namespaces/project-id-tier3.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier3-sa-tier3-dnsrecord-admin-host-project-id-permissions       | client-name-projects       |
+| namespaces/project-id-tier3.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy               | project-id-tier3-sa-workload-identity-binding                               | client-name-config-control |
+| namespaces/project-id-tier3.yaml | v1                                            | Namespace                      | project-id-tier3                                                            |                            |
+| namespaces/project-id-tier3.yaml | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext         | configconnectorcontext.core.cnrm.cloud.google.com                           | project-id-tier3           |
+| namespaces/project-id-tier3.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | cnrm-viewer-project-id-tier3                                                | networking                 |
+| namespaces/project-id-tier3.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | cnrm-viewer-project-id-tier3                                                | client-name-networking     |
+| namespaces/project-id-tier3.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | cnrm-viewer-project-id-tier3                                                | project-id-tier4           |
+| namespaces/project-id-tier3.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | syncs-repo                                                                  | project-id-tier3           |
+| namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount              | project-id-tier4-sa                                                         | client-name-config-control |
+| namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier4-sa-editor-project-id-permissions                           | client-name-projects       |
+| namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier4-sa-networkuser-host-project-id-permissions                 | client-name-projects       |
+| namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier4-sa-instanceadmin-project-id-permissions                    | client-name-projects       |
+| namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy               | project-id-tier4-sa-workload-identity-binding                               | client-name-config-control |
+| namespaces/project-id-tier4.yaml | v1                                            | Namespace                      | project-id-tier4                                                            |                            |
+| namespaces/project-id-tier4.yaml | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext         | configconnectorcontext.core.cnrm.cloud.google.com                           | project-id-tier4           |
+| namespaces/project-id-tier4.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | cnrm-viewer-project-id-tier4                                                | client-name-networking     |
+| namespaces/project-id-tier4.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | cnrm-viewer-project-id-tier4                                                | project-id-tier3           |
+| namespaces/project-id-tier4.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | syncs-repo                                                                  | project-id-tier4           |
+| project-iam.yaml                 | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | client-name-config-control-sa-iamserviceaccountadmin-project-id-permissions | client-name-projects       |
+| project.yaml                     | resourcemanager.cnrm.cloud.google.com/v1beta1 | Project                        | project-id                                                                  | client-name-projects       |
+| project.yaml                     | compute.cnrm.cloud.google.com/v1beta1         | ComputeSharedVPCServiceProject | project-id-svpcservice                                                      | client-name-networking     |
+| root-sync-git/root-sync-git.yaml | configsync.gke.io/v1beta1                     | RootSync                       | project-id-csync                                                            | config-management-system   |
+| services.yaml                    | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                        | project-id-iam                                                              | client-name-projects       |
+| services.yaml                    | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                        | project-id-resourcemanager                                                  | client-name-projects       |
+| services.yaml                    | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                        | project-id-billing                                                          | client-name-projects       |
+| services.yaml                    | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                        | project-id-serviceusage                                                     | client-name-projects       |
+
+## Resource References
+
+- RootSync
+- [ComputeSharedVPCServiceProject](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computesharedvpcserviceproject)
+- [ConfigConnectorContext](https://cloud.google.com/config-connector/docs/how-to/advanced-install#addon-configuring)
+- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [IAMServiceAccount](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount)
+- [Namespace](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#namespace-v1-core)
+- [Project](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/project)
+- [RoleBinding](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#rolebinding-v1-rbac-authorization-k8s-io)
+- [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/client-project-setup@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd ".//solutions/client-project-setup/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/client-project-setup/README.md
+++ b/solutions/client-project-setup/README.md
@@ -15,13 +15,13 @@ Package to create a client's project, 2 project scoped namespaces for its resour
 |             Name             |              Value              | Type | Count |
 |------------------------------|---------------------------------|------|-------|
 | client-management-project-id | client-management-project-12345 | str  |     1 |
-| client-name                  | client1                         | str  |    51 |
+| client-name                  | client1                         | str  |    50 |
 | host-project-id              | net-host-project-12345          | str  |     7 |
 | management-namespace         | config-control                  | str  |     8 |
 | management-project-id        | management-project-12345        | str  |     2 |
 | org-id                       |                      0000000000 | str  |     2 |
 | project-billing-id           | AAAAAA-BBBBBB-CCCCCC            | str  |     1 |
-| project-id                   | client-project-12345            | str  |    91 |
+| project-id                   | client-project-12345            | str  |    88 |
 | project-parent-folder        | project-parent-folder           | str  |     2 |
 | repo-branch                  | main                            | str  |     1 |
 | repo-dir                     | csync/deploy/env                | str  |     1 |
@@ -43,7 +43,6 @@ This package has no sub-packages.
 | namespaces/project-id-tier3.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy               | project-id-tier3-sa-workload-identity-binding                               | client-name-config-control |
 | namespaces/project-id-tier3.yaml | v1                                            | Namespace                      | project-id-tier3                                                            |                            |
 | namespaces/project-id-tier3.yaml | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext         | configconnectorcontext.core.cnrm.cloud.google.com                           | project-id-tier3           |
-| namespaces/project-id-tier3.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | cnrm-viewer-project-id-tier3                                                | networking                 |
 | namespaces/project-id-tier3.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | cnrm-viewer-project-id-tier3                                                | client-name-networking     |
 | namespaces/project-id-tier3.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | cnrm-viewer-project-id-tier3                                                | project-id-tier4           |
 | namespaces/project-id-tier3.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | syncs-repo                                                                  | project-id-tier3           |

--- a/solutions/client-project-setup/namespaces/project-id-tier3.yaml
+++ b/solutions/client-project-setup/namespaces/project-id-tier3.yaml
@@ -139,24 +139,6 @@ metadata:
 spec:
   googleServiceAccount: tier3-sa@project-id.iam.gserviceaccount.com # kpt-set: tier3-sa@${project-id}.iam.gserviceaccount.com
 ---
-# Give KCC, for this namespace, permission to read KCC resources in the networking namespace.
-# This allows to reference networking resources in the hub project.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: cnrm-viewer-project-id-tier3 # kpt-set: cnrm-viewer-${project-id}-tier3
-  namespace: networking
-  annotations:
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
-roleRef:
-  name: cnrm-viewer
-  kind: ClusterRole
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - name: cnrm-controller-manager-project-id-tier3 # kpt-set: cnrm-controller-manager-${project-id}-tier3
-    namespace: cnrm-system
-    kind: ServiceAccount
----
 # Give KCC, for this namespace, permission to read KCC resources in the client-name-networking namespace.
 # This allows to reference the network resources in the client-name-networking namespace from the tier3 namespace.
 apiVersion: rbac.authorization.k8s.io/v1

--- a/solutions/client-project-setup/namespaces/project-id-tier3.yaml
+++ b/solutions/client-project-setup/namespaces/project-id-tier3.yaml
@@ -1,0 +1,208 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# GCP SA
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: project-id-tier3-sa # kpt-set: ${project-id}-tier3-sa
+  namespace: client-name-config-control # kpt-set: ${client-name}-${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceID: tier3-sa
+  displayName: tier3-sa
+---
+# Grant GCP role IAM service account admin to GCP SA on Service Project
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier3-sa-serviceaccountadmin-project-id-permissions # kpt-set: ${project-id}-tier3-sa-serviceaccountadmin-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: roles/iam.serviceAccountAdmin
+  member: "serviceAccount:tier3-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier3-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant GCP role Security Admin to GCP SA on Service Project
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier3-sa-securityadmin-project-id-permissions # kpt-set: ${project-id}-tier3-sa-securityadmin-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: roles/iam.securityAdmin
+  member: "serviceAccount:tier3-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier3-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant GCP role Tier3 Firewall Rule Admin to GCP SA on Client Host Project
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier3-sa-tier3-firewallrule-admin-host-project-id-permissions # kpt-set: ${project-id}-tier3-sa-tier3-firewallrule-admin-${host-project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: host-project-id # kpt-set: ${host-project-id}
+  role: organizations/org-id/roles/tier3.firewallrule.admin # kpt-set: organizations/${org-id}/roles/tier3.firewallrule.admin
+  member: "serviceAccount:tier3-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier3-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant GCP role Tier3 DNS Record Admin to GCP SA on Client Host Project
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier3-sa-tier3-dnsrecord-admin-host-project-id-permissions # kpt-set: ${project-id}-tier3-sa-tier3-dnsrecord-admin-${host-project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: host-project-id # kpt-set: ${host-project-id}
+  role: organizations/org-id/roles/tier3.dnsrecord.admin # kpt-set: organizations/${org-id}/roles/tier3.dnsrecord.admin
+  member: "serviceAccount:tier3-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier3-sa@${project-id}.iam.gserviceaccount.com
+---
+# K8S SA
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata:
+  name: project-id-tier3-sa-workload-identity-binding # kpt-set: ${project-id}-tier3-sa-workload-identity-binding
+  namespace: client-name-config-control # kpt-set: ${client-name}-${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    name: project-id-tier3-sa # kpt-set: ${project-id}-tier3-sa
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    namespace: client-name-config-control # kpt-set: ${client-name}-${management-namespace}
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-project-id-tier3] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-${project-id}-tier3]
+---
+# K8S namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+---
+# Link GCP SA to K8S namespace
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  googleServiceAccount: tier3-sa@project-id.iam.gserviceaccount.com # kpt-set: tier3-sa@${project-id}.iam.gserviceaccount.com
+---
+# Give KCC, for this namespace, permission to read KCC resources in the networking namespace.
+# This allows to reference networking resources in the hub project.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cnrm-viewer-project-id-tier3 # kpt-set: cnrm-viewer-${project-id}-tier3
+  namespace: networking
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+roleRef:
+  name: cnrm-viewer
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: cnrm-controller-manager-project-id-tier3 # kpt-set: cnrm-controller-manager-${project-id}-tier3
+    namespace: cnrm-system
+    kind: ServiceAccount
+---
+# Give KCC, for this namespace, permission to read KCC resources in the client-name-networking namespace.
+# This allows to reference the network resources in the client-name-networking namespace from the tier3 namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cnrm-viewer-project-id-tier3 # kpt-set: cnrm-viewer-${project-id}-tier3
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+roleRef:
+  name: cnrm-viewer
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: cnrm-controller-manager-project-id-tier3 # kpt-set: cnrm-controller-manager-${project-id}-tier3
+    namespace: cnrm-system
+    kind: ServiceAccount
+---
+# Give KCC, for this namespace, permission to read KCC resources in the tier4 namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cnrm-viewer-project-id-tier3 # kpt-set: cnrm-viewer-${project-id}-tier3
+  namespace: project-id-tier4 # kpt-set: ${project-id}-tier4
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+roleRef:
+  name: cnrm-viewer
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: cnrm-controller-manager-project-id-tier3 # kpt-set: cnrm-controller-manager-${project-id}-tier3
+    namespace: cnrm-system
+    kind: ServiceAccount
+---
+# Repo sync role binding requirement
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: syncs-repo
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+subjects:
+  - kind: ServiceAccount
+    name: ns-reconciler-project-id-tier3 # kpt-set: ns-reconciler-${project-id}-tier3
+    namespace: config-management-system
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/solutions/client-project-setup/namespaces/project-id-tier4.yaml
+++ b/solutions/client-project-setup/namespaces/project-id-tier4.yaml
@@ -1,0 +1,174 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# GCP SA
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: project-id-tier4-sa # kpt-set: ${project-id}-tier4-sa
+  namespace: client-name-config-control # kpt-set: ${client-name}-${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceID: tier4-sa
+  displayName: tier4-sa
+---
+# Grant GCP role Editor to GCP SA
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier4-sa-editor-project-id-permissions # kpt-set: ${project-id}-tier4-sa-editor-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: roles/editor
+  member: "serviceAccount:tier4-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier4-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant GCP role Network User to GCP SA on Host Project
+# https://cloud.google.com/iam/docs/job-functions/networking
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier4-sa-networkuser-host-project-id-permissions # kpt-set: ${project-id}-tier4-sa-networkuser-${host-project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: host-project-id # kpt-set: ${host-project-id}
+  role: roles/compute.networkUser
+  member: "serviceAccount:tier4-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier4-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant GCP role Compute Instance Admin to GCP SA
+# https://cloud.google.com/iam/docs/job-functions/networking
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier4-sa-instanceadmin-project-id-permissions # kpt-set: ${project-id}-tier4-sa-instanceadmin-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: roles/compute.instanceAdmin
+  member: "serviceAccount:tier4-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier4-sa@${project-id}.iam.gserviceaccount.com
+---
+# K8S SA
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata:
+  name: project-id-tier4-sa-workload-identity-binding # kpt-set: ${project-id}-tier4-sa-workload-identity-binding
+  namespace: client-name-config-control # kpt-set: ${client-name}-${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    name: project-id-tier4-sa # kpt-set: ${project-id}-tier4-sa
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    namespace: client-name-config-control # kpt-set: ${client-name}-${management-namespace}
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-project-id-tier4] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-${project-id}-tier4]
+---
+# K8S namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: project-id-tier4 # kpt-set: ${project-id}-tier4
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+---
+# Link GCP SA to K8S namespace
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: project-id-tier4 # kpt-set: ${project-id}-tier4
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  googleServiceAccount: tier4-sa@project-id.iam.gserviceaccount.com # kpt-set: tier4-sa@${project-id}.iam.gserviceaccount.com
+---
+# Give KCC, for this namespace, permission to read KCC resources in the client-name-networking namespace.
+# This allows GKE and GCE instances to reference the shared network in the client-name-networking namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cnrm-viewer-project-id-tier4 # kpt-set: cnrm-viewer-${project-id}-tier4
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+roleRef:
+  name: cnrm-viewer
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: cnrm-controller-manager-project-id-tier4 # kpt-set: cnrm-controller-manager-${project-id}-tier4
+    namespace: cnrm-system
+    kind: ServiceAccount
+---
+# Give KCC, for this namespace, permission to read KCC resources in the tier3 namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cnrm-viewer-project-id-tier4 # kpt-set: cnrm-viewer-${project-id}-tier4
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+roleRef:
+  name: cnrm-viewer
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: cnrm-controller-manager-project-id-tier4 # kpt-set: cnrm-controller-manager-${project-id}-tier4
+    namespace: cnrm-system
+    kind: ServiceAccount
+---
+# Repo sync role binding requirement
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: syncs-repo
+  namespace: project-id-tier4 # kpt-set: ${project-id}-tier4
+subjects:
+  - kind: ServiceAccount
+    name: ns-reconciler-project-id-tier4 # kpt-set: ns-reconciler-${project-id}-tier4
+    namespace: config-management-system
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/solutions/client-project-setup/namespaces/project-id-tier4.yaml
+++ b/solutions/client-project-setup/namespaces/project-id-tier4.yaml
@@ -56,6 +56,7 @@ metadata:
     cnrm.cloud.google.com/ignore-clusterless: "true"
     config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
 spec:
+  # TODO: revisit to potentially grant networkUser on a subnet instead of project
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project

--- a/solutions/client-project-setup/project-iam.yaml
+++ b/solutions/client-project-setup/project-iam.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# First, Grant GCP Role IAM service account admin on project to client-config-control SA so that it can create service accounts.
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: client-name-config-control-sa-iamserviceaccountadmin-project-id-permissions # kpt-set: ${client-name}-${management-namespace}-sa-iamserviceaccountadmin-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: roles/iam.serviceAccountAdmin
+  member: "serviceAccount:client-name-config-control-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-${management-namespace}-sa@${client-management-project-id}.iam.gserviceaccount.com

--- a/solutions/client-project-setup/project.yaml
+++ b/solutions/client-project-setup/project.yaml
@@ -1,0 +1,44 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Project
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  name: project-id # kpt-set: ${project-id}
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/auto-create-network: "false"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-hierarchy/Folder/project-parent-folder # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-hierarchy/Folder/${project-parent-folder}
+spec:
+  name: project-id # kpt-set: ${project-id}
+  billingAccountRef:
+    external: "AAAAAA-BBBBBB-CCCCCC" # kpt-set: ${project-billing-id}
+  folderRef:
+    name: project-parent-folder # kpt-set: ${project-parent-folder}
+    namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+---
+# Activate service project
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSharedVPCServiceProject
+metadata:
+  name: project-id-svpcservice # kpt-set: ${project-id}-svpcservice
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  projectRef:
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects

--- a/solutions/client-project-setup/root-sync-git/root-sync-git.yaml
+++ b/solutions/client-project-setup/root-sync-git/root-sync-git.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Root Sync for client project resources and Repo Syncs
+apiVersion: configsync.gke.io/v1beta1
+kind: RootSync
+metadata:
+  name: project-id-csync # kpt-set: ${project-id}-csync
+  namespace: config-management-system
+spec:
+  sourceFormat: unstructured
+  git:
+    repo: https://repo-url # kpt-set: ${repo-url}
+    branch: main # kpt-set: ${repo-branch}
+    dir: csync/deploy/env # kpt-set: ${repo-dir}
+    revision: HEAD
+    auth: token
+    secretRef:
+      name: git-creds

--- a/solutions/client-project-setup/services.yaml
+++ b/solutions/client-project-setup/services.yaml
@@ -1,0 +1,69 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# IAM API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-iam # kpt-set: ${project-id}-iam
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: iam.googleapis.com
+---
+# Resource Manager API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-resourcemanager # kpt-set: ${project-id}-resourcemanager
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: cloudresourcemanager.googleapis.com
+---
+# Billing API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-billing # kpt-set: ${project-id}-billing
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: cloudbilling.googleapis.com
+---
+# Service Usage API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-serviceusage # kpt-set: ${project-id}-serviceusage
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: serviceusage.googleapis.com

--- a/solutions/client-project-setup/setters.yaml
+++ b/solutions/client-project-setup/setters.yaml
@@ -1,0 +1,97 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  # Project IDs must follow the rules below, additionally,
+  # if a gatekeeper policy is used to enforce specific naming conventions, refer to its documentation.
+  #   - All IDs should be universally unique.
+  #   - Must be 6 to 30 characters in length.
+  #   - Can only contain lowercase letters, numbers, and hyphens.
+  #   - Must start with a letter.
+  #   - Cannot end with a hyphen.
+  #   - Cannot be in use or previously used; this includes deleted projects.
+  #   - Cannot contain restricted strings, such as google and ssl.
+  #
+  ##########################
+  # General Settings Values
+  ##########################
+  #
+  org-id: "0000000000"
+  #
+  ##########################
+  # Management Project
+  ##########################
+  #
+  # This is the project where the config controller instance is running
+  # Values can be viewed in the Project Dashboard
+  management-project-id: management-project-12345
+  management-namespace: config-control
+  #
+  ##########################
+  # Client
+  ##########################
+  #
+  # Name for the client, lowercase only
+  client-name: 'client1'
+  # id of the client management project created in client-landing-zone
+  client-management-project-id: client-management-project-12345
+  #
+  ##########################
+  # Network Host Project (standard)
+  ##########################
+  #
+  # ID of existing Shared VPC host project to associate
+  host-project-id: net-host-project-12345
+  #
+  ##########################
+  # Project
+  ##########################
+  #
+  # project id for the client project to be created, following rules and conventions
+  project-id: client-project-12345
+  # Billing Account ID to be associated with this project
+  project-billing-id: "AAAAAA-BBBBBB-CCCCCC"
+  # GCP folder to use as parent to this project, lowercase K8S resource name
+  project-parent-folder: project-parent-folder
+  #
+  ##########################
+  # Config Sync
+  ##########################
+  #
+  # Used for the client root sync external git repo (GitHub, Azure DevOps, etc.)
+  # To disable this option, delete the 'root-sync-git/' directory
+  #
+  # the git repo URL, for example
+  # https://github.com/GITHUB-ORG/REPO-NAME
+  # https://AZDO-ORG@dev.azure.com/AZDO-ORG/AZDO-PROJECT/_git/REPO-NAME
+  repo-url: git-repo-to-observe
+  # the branch to check out (usually main)
+  repo-branch: main
+  # the directory to observe for YAML manifests
+  repo-dir: csync/deploy/env
+  #
+  ##########################
+  # End of Configurations
+  ##########################


### PR DESCRIPTION
new package for issue #370
(additional PRs will be created for other packages and to update documentation)

**`solutions/client-project-setup`**
- includes / deprecates packages:
    - none
- adds features:
    - client tier3 and tier4 namespaces
    - client tier3/4 root sync
    - client shared vpc service project
- depends on:
    - solutions/client-landing-zone
