### PR TITLE
feat: add experimentation admin folder package

### DIFF
--- a/solutions/experimentation/admin-folder/CHANGELOG.md
+++ b/solutions/experimentation/admin-folder/CHANGELOG.md
@@ -1,15 +1,1 @@
 # Changelog
-
-## [0.1.0](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/compare/solutions/hierarchy/admin-experimentation/0.0.2...solutions/hierarchy/admin-experimentation/0.1.0) (2023-03-21)
-
-
-### Features
-
-* add yaml linting and solutions validation ([#309](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/issues/309)) ([25fee09](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/commit/25fee09dd6c62931032569fbc2cc8bf090fd9266))
-
-## [0.0.2](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/compare/solutions/hierarchy/admin-experimentation-v0.0.1...solutions/hierarchy/admin-experimentation/0.0.2) (2023-03-03)
-
-
-### Bug Fixes
-
-* add CHANGELOG.md to pkg defined for release-please ([#285](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/issues/285)) ([39d8c8a](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/commit/39d8c8a5c41a0c500385ec432039260672296daf))

--- a/solutions/experimentation/admin-folder/CHANGELOG.md
+++ b/solutions/experimentation/admin-folder/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## [0.1.0](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/compare/solutions/hierarchy/admin-experimentation/0.0.2...solutions/hierarchy/admin-experimentation/0.1.0) (2023-03-21)
+
+
+### Features
+
+* add yaml linting and solutions validation ([#309](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/issues/309)) ([25fee09](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/commit/25fee09dd6c62931032569fbc2cc8bf090fd9266))
+
+## [0.0.2](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/compare/solutions/hierarchy/admin-experimentation-v0.0.1...solutions/hierarchy/admin-experimentation/0.0.2) (2023-03-03)
+
+
+### Bug Fixes
+
+* add CHANGELOG.md to pkg defined for release-please ([#285](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/issues/285)) ([39d8c8a](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/commit/39d8c8a5c41a0c500385ec432039260672296daf))

--- a/solutions/experimentation/admin-folder/Kptfile
+++ b/solutions/experimentation/admin-folder/Kptfile
@@ -7,6 +7,7 @@ metadata:
 info:
   description: |
     admin-folder
+    Depends on 'solutions/experimentation/core-landing-zone'
 
     Creates an admin folder underneath tests.admins
 pipeline:

--- a/solutions/experimentation/admin-folder/Kptfile
+++ b/solutions/experimentation/admin-folder/Kptfile
@@ -1,0 +1,15 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: experimentation-admin-folder
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    admin-folder
+
+    Creates an admin folder underneath tests.admins
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/experimentation/admin-folder/Kptfile
+++ b/solutions/experimentation/admin-folder/Kptfile
@@ -1,14 +1,13 @@
 apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
-  name: experimentation-admin-folder
+  name: admin-folder
   annotations:
     config.kubernetes.io/local-config: "true"
 info:
   description: |
-    admin-folder
+    admin-folder experimentation core landing-zone subpackage
     Depends on 'solutions/experimentation/core-landing-zone'
-
     Creates an admin folder underneath tests.admins
 pipeline:
   mutators:

--- a/solutions/experimentation/admin-folder/Kptfile
+++ b/solutions/experimentation/admin-folder/Kptfile
@@ -6,9 +6,11 @@ metadata:
     config.kubernetes.io/local-config: "true"
 info:
   description: |
-    admin-folder experimentation core landing-zone subpackage
-    Depends on 'solutions/experimentation/core-landing-zone'
+    Landing Zone v2 experimentation subpackage.
+    Depends on core-landing-zone
+
     Creates an admin folder underneath tests.admins
+    This package should only be deployed within a experimentation landing zone.
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/apply-setters:v0.2

--- a/solutions/experimentation/admin-folder/README.md
+++ b/solutions/experimentation/admin-folder/README.md
@@ -1,11 +1,76 @@
-# Introduction
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# admin-folder
 
-A package to create an admin folder in the experimentation landing zone
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+admin-folder experimentation core landing-zone subpackage
+Depends on 'solutions/experimentation/core-landing-zone'
+Creates an admin folder underneath tests.admins
+
+## Setters
+
+|    Name     |          Value          | Type | Count |
+|-------------|-------------------------|------|-------|
+| admin-name  | admin1                  | str  |     8 |
+| admin-owner | user:admin1@example.com | str  |     3 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|      File       |                  APIVersion                   |      Kind       |                      Name                       | Namespace |
+|-----------------|-----------------------------------------------|-----------------|-------------------------------------------------|-----------|
+| folder-iam.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember | admins.admin1-admin-folder-admin-permissions    | hierarchy |
+| folder-iam.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember | admins.admin1-admin-project-creator-permissions | hierarchy |
+| folder-iam.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember | admins.admin1-admin-owner-permissions           | hierarchy |
+| folder.yaml     | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder          | tests.admins.admin1                             | hierarchy |
+
+## Resource References
+
+- [Folder](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/folder)
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
 
 ## Usage
 
-Get the package by running the following, optionally setting the revision and destination folder:
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/experimentation/admin-folder/admin-folder@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
 
-`kpt pkg get <REPO URL>.git/experimentation/admin-folder@<REVISION> <DESTINATION_FOLDER>`
+1.  Move into the local package:
+    ```shell
+    cd "./admin-folder/"
+    ```
 
-Modify `setters.yaml` according to the onboarded admin.
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/experimentation/admin-folder/README.md
+++ b/solutions/experimentation/admin-folder/README.md
@@ -3,11 +3,12 @@
 
 
 <!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
-
 <!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
-admin-folder experimentation core landing-zone subpackage
-Depends on 'solutions/experimentation/core-landing-zone'
+Landing Zone v2 experimentation subpackage.
+Depends on core-landing-zone
+
 Creates an admin folder underneath tests.admins
+This package should only be deployed within a experimentation landing zone.
 
 ## Setters
 

--- a/solutions/experimentation/admin-folder/README.md
+++ b/solutions/experimentation/admin-folder/README.md
@@ -38,7 +38,7 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/experimentation/admin-folder/admin-folder@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/experimentation/admin-folder@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).

--- a/solutions/experimentation/admin-folder/README.md
+++ b/solutions/experimentation/admin-folder/README.md
@@ -1,0 +1,11 @@
+# Introduction
+
+A package to create an admin folder in the experimentation landing zone
+
+## Usage
+
+Get the package by running the following, optionally setting the revision and destination folder:
+
+`kpt pkg get <REPO URL>.git/experimentation/admin-folder@<REVISION> <DESTINATION_FOLDER>`
+
+Modify `setters.yaml` according to the onboarded admin.

--- a/solutions/experimentation/admin-folder/folder-iam.yaml
+++ b/solutions/experimentation/admin-folder/folder-iam.yaml
@@ -1,0 +1,64 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Grant GCP role Folder Admin on Admin's folder to admin
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: admins.admin1-admin-folder-admin-permissions # kpt-set: admins.${admin-name}-admin-folder-admin-permissions
+  namespace: hierarchy
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    name: tests.admins.admin1 # kpt-set: tests.admins.${admin-name}
+  role: roles/resourcemanager.folderAdmin
+  member: admin-owner # kpt-set: ${admin-owner}
+---
+# Grant GCP role Project Creator on Admin's folder to admin
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: admins.admin1-admin-project-creator-permissions # kpt-set: admins.${admin-name}-admin-project-creator-permissions
+  namespace: hierarchy
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    name: tests.admins.admin1 # kpt-set: tests.admins.${admin-name}
+  role: roles/resourcemanager.projectCreator
+  member: admin-owner # kpt-set: ${admin-owner}
+---
+# Grant GCP role Owner on Admin's folder to admin
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: admins.admin1-admin-owner-permissions # kpt-set: admins.${admin-name}-admin-owner-permissions
+  namespace: hierarchy
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    name: tests.admins.admin1 # kpt-set: tests.admins.${admin-name}
+  role: roles/owner
+  member: admin-owner # kpt-set: ${admin-owner}

--- a/solutions/experimentation/admin-folder/folder.yaml
+++ b/solutions/experimentation/admin-folder/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: tests.admins.admin1 # kpt-set: tests.admins.${admin-name}
+  namespace: hierarchy
+spec:
+  displayName: admin1 # kpt-set: ${admin-name}
+  folderRef:
+    name: tests.admins

--- a/solutions/experimentation/admin-folder/setters.yaml
+++ b/solutions/experimentation/admin-folder/setters.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  admin-name: 'admin1' # lowercase only
+  admin-owner: 'user:admin1@example.com'

--- a/solutions/experimentation/admin-folder/setters.yaml
+++ b/solutions/experimentation/admin-folder/setters.yaml
@@ -19,6 +19,15 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  # lowercase only
+  ##########################
+  # Admin
+  ##########################
+  #
+  # Name for the Admin, lowercase only
   admin-name: 'admin1'
+  # Group or User to grant permission on admin folder
   admin-owner: 'user:admin1@example.com'
+  #
+  ##########################
+  # End of Configurations
+  ##########################

--- a/solutions/experimentation/admin-folder/setters.yaml
+++ b/solutions/experimentation/admin-folder/setters.yaml
@@ -19,5 +19,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  admin-name: 'admin1' # lowercase only
+  # lowercase only
+  admin-name: 'admin1'
   admin-owner: 'user:admin1@example.com'


### PR DESCRIPTION
new package for issue #370
(additional PRs will be created for other packages and to update documentation)

**`solutions/experimentation/admin-folder`**
- includes / deprecates packages:
    - solutions/hierarchy/admin-experimentation
- depends on:
    - solutions/experimentation/core-landing-zone
