### PR TITLE
feat: add experimentation client-landing-zone package

### DIFF
--- a/solutions/experimentation/client-landing-zone/Kptfile
+++ b/solutions/experimentation/client-landing-zone/Kptfile
@@ -1,0 +1,16 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: client-landing-zone
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    Landing zone v2 experimentation subpackage.
+    Depends on `experimentation/core-landing-zone`.
+
+    Package to create a client's folder hierarchy and logging resources.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/experimentation/client-landing-zone/README.md
+++ b/solutions/experimentation/client-landing-zone/README.md
@@ -1,0 +1,85 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# client-landing-zone
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+Landing zone v2 experimentation subpackage.
+Depends on `experimentation/core-landing-zone`.
+
+Package to create a client's folder hierarchy and logging resources.
+
+## Setters
+
+|           Name           |           Value           | Type | Count |
+|--------------------------|---------------------------|------|-------|
+| client-folderviewer      | group:client1@example.com | str  |     1 |
+| client-name              | client1                   | str  |    13 |
+| logging-project-id       | logging-project-12345     | str  |     4 |
+| retention-in-days        |                         1 | int  |     1 |
+| retention-locking-policy | false                     | bool |     1 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|                   File                    |                  APIVersion                   |       Kind       |                               Name                               | Namespace |
+|-------------------------------------------|-----------------------------------------------|------------------|------------------------------------------------------------------|-----------|
+| client-folder/applications/folder.yaml    | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder           | clients.client-name.applications                                 | hierarchy |
+| client-folder/folder-iam.yaml             | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember  | clients.client-name-client-folder-viewer-permissions             | hierarchy |
+| client-folder/folder-sink.yaml            | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink   | platform-and-component-log-client-name-log-sink                  | logging   |
+| client-folder/folder.yaml                 | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder           | clients.client-name                                              | hierarchy |
+| logging-project/cloud-logging-bucket.yaml | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogBucket | platform-and-component-client-name-log-bucket                    | logging   |
+| logging-project/project-iam.yaml          | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy | platform-and-component-log-client-name-bucket-writer-permissions | projects  |
+
+## Resource References
+
+- [Folder](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/folder)
+- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [LoggingLogBucket](https://cloud.google.com/config-connector/docs/reference/resource-docs/logging/logginglogbucket)
+- [LoggingLogSink](https://cloud.google.com/config-connector/docs/reference/resource-docs/logging/logginglogsink)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/experimentation/client-landing-zone@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd ".//solutions/experimentation/client-landing-zone/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/experimentation/client-landing-zone/client-folder/applications/folder.yaml
+++ b/solutions/experimentation/client-landing-zone/client-folder/applications/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: clients.client-name.applications # kpt-set: clients.${client-name}.applications
+  namespace: hierarchy
+spec:
+  displayName: applications
+  folderRef:
+    name: clients.client-name # kpt-set: clients.${client-name}

--- a/solutions/experimentation/client-landing-zone/client-folder/folder-iam.yaml
+++ b/solutions/experimentation/client-landing-zone/client-folder/folder-iam.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Grant GCP role Folder Viewer on client's folder to client's user group
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: clients.client-name-client-folder-viewer-permissions # kpt-set: clients.${client-name}-client-folder-viewer-permissions
+  namespace: hierarchy
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    name: clients.client-name # kpt-set: clients.${client-name}
+  role: roles/resourcemanager.folderViewer
+  member: client-folderviewer # kpt-set: ${client-folderviewer}

--- a/solutions/experimentation/client-landing-zone/client-folder/folder-sink.yaml
+++ b/solutions/experimentation/client-landing-zone/client-folder/folder-sink.yaml
@@ -1,0 +1,56 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Folder sink for Platform and Component logs of Client Resources
+# Destination: cloud logging bucket inside logging project
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogSink
+metadata:
+  name: platform-and-component-log-client-name-log-sink # kpt-set: platform-and-component-log-${client-name}-log-sink
+  namespace: logging
+  annotations:
+    config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/platform-and-component-client-name-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/platform-and-component-${client-name}-log-bucket
+spec:
+  folderRef:
+    name: clients.client-name # kpt-set: clients.${client-name}
+    namespace: hierarchy
+  includeChildren: true
+  destination:
+    loggingLogBucketRef:
+      # destination.loggingLogBucketRef
+      # Only `external` field is supported to configure the reference.
+      external: platform-and-component-client-name-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/platform-and-component-${client-name}-log-bucket
+  description: Folder sink for client-name Platform and Component logs # kpt-set: Folder sink for ${client-name} Platform and Component logs
+  # AU-2, AU-12(A), AU-12(C)
+  # Includes the following types of logs:
+  # Cloud DNS, Cloud NAT, Firewall Rules, VPC Flow, and HTTP(S) Load Balancer
+  # These logs are not enabled by default. They are enabled inside the client-experimentation package:
+  # https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/project/project-experimentation
+  filter: |-
+    LOG_ID("dns.googleapis.com/dns_queries")
+    OR (LOG_ID("compute.googleapis.com/nat_flows") AND resource.type="nat_gateway")
+    OR (LOG_ID("compute.googleapis.com/firewall") AND resource.type="gce_subnetwork")
+    OR (LOG_ID("compute.googleapis.com/vpc_flows") AND resource.type="gce_subnetwork")
+    OR (LOG_ID("requests") AND resource.type="http_load_balancer")
+  # Excludes all Security logs: Cloud Audit, Access Transparency, and Data Access Logs
+  exclusions:
+    - description: Exclude Security logs
+      disabled: false
+      filter: |-
+        LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("externalaudit.googleapis.com/activity")
+        OR LOG_ID("cloudaudit.googleapis.com/data_access") OR LOG_ID("externalaudit.googleapis.com/data_access")
+        OR LOG_ID("cloudaudit.googleapis.com/system_event") OR LOG_ID("externalaudit.googleapis.com/system_event")
+        OR LOG_ID("cloudaudit.googleapis.com/policy") OR LOG_ID("externalaudit.googleapis.com/policy")
+        OR LOG_ID("cloudaudit.googleapis.com/access_transparency") OR LOG_ID("externalaudit.googleapis.com/access_transparency")
+      name: exclude-security-logs

--- a/solutions/experimentation/client-landing-zone/client-folder/folder.yaml
+++ b/solutions/experimentation/client-landing-zone/client-folder/folder.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: clients.client-name # kpt-set: clients.${client-name}
+  namespace: hierarchy
+spec:
+  displayName: client-name-experimentation # kpt-set: ${client-name}-experimentation
+  folderRef:
+    name: clients

--- a/solutions/experimentation/client-landing-zone/logging-project/cloud-logging-bucket.yaml
+++ b/solutions/experimentation/client-landing-zone/logging-project/cloud-logging-bucket.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Cloud Logging bucket for client Platform and Component logs
+# Logs are routed using a log sink to a central logging project into a dedicated log bucket
+# AU-4(1), AU-9(2) - Log buckets are created in a logging project, isolating them from the source of the log entries in other projects
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogBucket
+metadata:
+  name: platform-and-component-client-name-log-bucket # kpt-set: platform-and-component-${client-name}-log-bucket
+  namespace: logging
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id}
+spec:
+  projectRef:
+    name: logging-project-id # kpt-set: ${logging-project-id}
+    namespace: projects
+  location: northamerica-northeast1
+  description: Cloud Logging bucket for client-name Platform and Component logs # kpt-set: Cloud Logging bucket for ${client-name} Platform and Component logs
+  # Implement retention policy and retention locking policy
+  # AU-9, AU-11 - RetentionDays sets the policy where existing log content cannot be changed/deleted for the specificied number of days (from setters.yaml), locked setting means policy cannot be changed, ensuring immutability.
+  locked: false # kpt-set: ${retention-locking-policy}
+  retentionDays: 1 # kpt-set: ${retention-in-days}

--- a/solutions/experimentation/client-landing-zone/logging-project/project-iam.yaml
+++ b/solutions/experimentation/client-landing-zone/logging-project/project-iam.yaml
@@ -1,0 +1,36 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Logs Bucket writer IAM permissions
+# Binds the generated Writer identity from the LoggingLogSink to the logging project
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata:
+  name: platform-and-component-log-client-name-bucket-writer-permissions # kpt-set: platform-and-component-log-${client-name}-bucket-writer-permissions
+  namespace: projects
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id}
+spec:
+  resourceRef:
+    kind: Project
+    name: logging-project-id # kpt-set: ${logging-project-id}
+    namespace: projects
+  # AC-3(7) - Write access to the logging buckets is limited by IAM to just the identities of the log sinks configured to send logs to the buckets (set at the logging project level)
+  bindings:
+    - role: roles/logging.bucketWriter
+      members:
+        - memberFrom:
+            logSinkRef:
+              name: platform-and-component-log-client-name-sink # kpt-set: platform-and-component-log-${client-name}-log-sink
+              namespace: logging

--- a/solutions/experimentation/client-landing-zone/logging-project/securitycontrols.md
+++ b/solutions/experimentation/client-landing-zone/logging-project/securitycontrols.md
@@ -1,0 +1,51 @@
+# Security Controls
+>
+> TODO: This document requires refinement.
+
+## AC-3 ACCESS ENFORCEMENT
+
+## AC-3(7) ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+
+AC-3(7) – Write access to the logs is constrained by IAM permissions to just the log sinks.
+This control should be added to project-iam.yaml. Lines 15/16 already have a good explanation of
+what’s happening so just add the AC-3(7) tag around there)
+
+## AU-2 AUDITABLE EVENTS
+
+AU-2 – Event families being audited are set here. This control should be added to the folder-sink.yaml,
+gke-kcc-sink.yaml and org-sink.yaml with a brief explanation of what’s being audited.
+Suggest putting the tag and explanation down around line 35 where the inclusions/exclusions are
+This is an org control so the AU-2 tagging in the code is there to support the narrative Ops will write to demonstrate the org requirements
+
+## AU-4 AUDIT STORAGE CAPACITY
+
+## AU-4(1) AUDIT STORAGE CAPACITY | TRANSFER TO ALTERNATE STORAGE
+
+AU-4(1) – Logs are being sent to a logging project which is separate from the projects
+performing actions which generate log entries. This control should be added to the
+cloud-logging-buckets.yaml with a brief explanation that the logs are in a separate project.
+Suggest putting around line 15 which describes buckets
+
+## AU-8 TIME STAMPS
+
+AU-8 – Time stamps for audit records use internal Google time. Statement to that effect should go into securitycontrols.md, will need a reference to some Google documentation (can be found later)
+
+## AU-9 PROTECTION OF AUDIT INFORMATION
+
+AU-9 – Retention policies and policy locks are implemented so log contents is immutable. Include in cloud-logging-buckets.yaml after lines 28 and 46 (i.e. just before the “locked” and “retentionDays” settings. Also add to setters.yaml. Also add notation to project-iam.yaml where roles are being assigned to the sinks (same as AC-3(7))
+
+## AU-9(2) PROTECTION OF AUDIT INFORMATION | AUDIT BACKUP ON SEPARATE PHYSICAL SYSTEMS / COMPONENTS
+
+AU-9(2) – Logs sent to separate project, same response as AU-4(1)
+
+## AU-11 AUDIT RECORD RETENTION
+
+AU-11 – Audit log retention, same response as AU-9 however no reference added to project-iam.yaml as AU-11 doesn’t deal with access
+
+## AU-12 AUDIT GENERATION
+
+## AU-12(A)
+
+## AU-12(C)
+
+AU-12(A), AU-12(C) – This is the implementation of AU-2, so same comments and code locations apply

--- a/solutions/experimentation/client-landing-zone/setters.yaml
+++ b/solutions/experimentation/client-landing-zone/setters.yaml
@@ -1,0 +1,65 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  # Project IDs must follow the rules below, additionally,
+  # if a gatekeeper policy is used to enforce specific naming conventions, refer to its documentation.
+  #   - All IDs should be universally unique.
+  #   - Must be 6 to 30 characters in length.
+  #   - Can only contain lowercase letters, numbers, and hyphens.
+  #   - Must start with a letter.
+  #   - Cannot end with a hyphen.
+  #   - Cannot be in use or previously used; this includes deleted projects.
+  #   - Cannot contain restricted strings, such as google and ssl.
+  #
+  ##########################
+  # Client
+  ##########################
+  #
+  # Name for the client, lowercase only
+  client-name: 'client1'
+  # group to grant viewer permission on client folder
+  client-folderviewer: 'group:client1@example.com'
+  #
+  ##########################
+  # Logging
+  ##########################
+  #
+  # logging project id created in core-landing-zone
+  logging-project-id: logging-project-12345
+  #
+  # LoggingLogBucket retention settings
+  # Set the number of days to retain logs in Cloud Logging buckets
+  # Set the lock mechanism on the bucket to: true or false
+  # After a retention policy is locked (true), you can't delete the bucket until every log in the bucket has fulfilled the bucket's retention period
+  # AU-9 PROTECTION OF AUDIT INFORMATION
+  # AU-11 AUDIT RECORD RETENTION
+  # The values below must be modified to locked: true and retentionDays: 365 in a Production setting to implement above mentioned security controls.
+  retention-locking-policy: "false"
+  retention-in-days: "1"
+  #
+  ##########################
+  # End of Configurations
+  ##########################


### PR DESCRIPTION
new package for issue #370
(additional PRs will be created for other packages and to update documentation)

**`solutions/experimentation/client-landing-zone`**
- includes / deprecates packages:
    - solutions/hierarchy/client-experimentation
    - solutions/logging/client-experimentation
- depends on:
    - solutions/experimentation/core-landing-zone
