### PR TITLE
feat: add cloud armor resources

### DIFF
--- a/examples/landing-zone-v2/Kptfile
+++ b/examples/landing-zone-v2/Kptfile
@@ -1,15 +1,13 @@
 apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
-  name: example-firewall-policy-rules
+  name: example-packages
   annotations:
     config.kubernetes.io/local-config: "true"
 info:
   description: |
-    Landing zone v2 tier3 resource example.
+    Landing zone v2 client resources examples.
     Depends on `client-project-setup`.
-
-    Example to create a firewall rule in an existing policy from a client's project (tier3 namespace)
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/apply-setters:v0.2

--- a/examples/landing-zone-v2/README.md
+++ b/examples/landing-zone-v2/README.md
@@ -1,5 +1,11 @@
-# Example Resources
+# Example Client Project Resources
 
 > Work in progress.
 
-Example resources which can be deployed in client namespaces.
+Examples which can be used as a starting point to deploy resources in the client project namespaces (tier3/tier4).
+They are not meant to be deployed as-is.
+Remove/add/edit examples as required.
+
+A top level `Kptfile` and common `setters.yaml` is provided but can be edited/removed/moved as required.
+
+Some could be deployed multiple times for different workloads (i.e. load balancers), some only once per project (i.e. IAM permissions to create load balancers in the project).

--- a/examples/landing-zone-v2/setters.yaml
+++ b/examples/landing-zone-v2/setters.yaml
@@ -23,3 +23,7 @@ data:
   client-name: 'client1'
   # The project id of the client
   project-id: client-project-12345
+  # the id of the network host project
+  host-project-id: host-project-12345
+  # the name of the workload, lowercase only
+  workload-name: workload1

--- a/examples/landing-zone-v2/tier3/cloud-armor/README.md
+++ b/examples/landing-zone-v2/tier3/cloud-armor/README.md
@@ -1,0 +1,25 @@
+# Cloud Armor
+
+This example creates a Cloud Armor policy which can be later applied to targets (load balancer backend service).
+
+[https://cloud.google.com/armor/docs/security-policy-overview](https://cloud.google.com/armor/docs/security-policy-overview)
+
+## IAM
+The following permissions are required on the project for the tier3-sa in order to manage policies:
+
+```yaml
+# iam-cloud-armor.yaml
+# Grant GCP role Compute Security Admin to tier3-sa GCP SA for Cloud Armor
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier3-sa-computesecurityadmin-permissions # kpt-set: ${project-id}-tier3-sa-computesecurityadmin-permissions
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    kind: Project
+    external: projects/project-id # kpt-set: projects/${project-id}
+  role: roles/compute.securityAdmin
+  member: "serviceAccount:tier3-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier3-sa@${project-id}.iam.gserviceaccount.com
+```

--- a/examples/landing-zone-v2/tier3/cloud-armor/security-policy.yaml
+++ b/examples/landing-zone-v2/tier3/cloud-armor/security-policy.yaml
@@ -1,0 +1,68 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# creates a cloud armor policy with rules
+# the target load balancer is attached from its ComputeBackendService resource
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSecurityPolicy
+metadata:
+  name: workload-name-security-policy # kpt-set: ${workload-name}-security-policy
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: workload-name-security-policy # kpt-set: ${workload-name}-security-policy
+  rule:
+    - action: deny(403)
+      description: block preconfiguredWAF list
+      match:
+        expr:
+          expression: |
+            evaluatePreconfiguredExpr('lfi-stable')
+            || evaluatePreconfiguredExpr('rce-stable')
+            || evaluatePreconfiguredExpr('scannerdetection-stable')
+            || evaluatePreconfiguredExpr('protocolattack-stable')
+            || evaluatePreconfiguredExpr('sessionfixation-stable')
+      priority: 10000
+    - action: allow
+      description: allow Canada
+      match:
+        expr:
+          expression: |
+            '[CA]'.contains(origin.region_code)
+      priority: 100001
+    - action: allow
+      description: allow Google monitoring
+      match:
+        expr:
+          expression: |
+            request.headers['user-agent'].contains('GoogleStackdriverMonitoring-UptimeChecks')
+      priority: 100000
+    - action: allow
+      description: allow web security scanner
+      match:
+        config:
+          srcIpRanges:
+            - 34.66.18.0/26
+            - 34.66.114.64/26
+        versionedExpr: SRC_IPS_V1
+      priority: 100002
+    - action: deny(403)
+      description: Default rule, higher priority overrides it
+      match:
+        config:
+          srcIpRanges:
+            - '*'
+        versionedExpr: SRC_IPS_V1
+      priority: 2147483647
+  type: CLOUD_ARMOR

--- a/examples/landing-zone-v2/tier3/external-load-balancer/README.md
+++ b/examples/landing-zone-v2/tier3/external-load-balancer/README.md
@@ -1,0 +1,27 @@
+# External Load Balancer
+
+This example creates all components of a simple external load balancer with its backend service attaching to an existing Cloud Armor policy and a managed instance group (created in tier4).
+
+![img](https://cloud.google.com/static/load-balancing/images/http-load-balancer-simple.svg)
+
+[https://cloud.google.com/load-balancing/docs/https/setup-global-ext-https-compute](https://cloud.google.com/load-balancing/docs/https/setup-global-ext-https-compute)
+
+## IAM
+The following permissions are required on the project for the tier3-sa in order to manage load balancer resources:
+
+```yaml
+# iam-elb.yaml
+# Grant GCP role Compute Security Admin to tier3-sa GCP SA for load balancer resources
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier3-sa-lbadmin-permissions # kpt-set: ${project-id}-tier3-sa-lbadmin-permissions
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    kind: Project
+    external: projects/project-id # kpt-set: projects/${project-id}
+  role: roles/compute.loadBalancerAdmin
+  member: "serviceAccount:tier3-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier3-sa@${project-id}.iam.gserviceaccount.com
+```

--- a/examples/landing-zone-v2/tier3/external-load-balancer/address.yaml
+++ b/examples/landing-zone-v2/tier3/external-load-balancer/address.yaml
@@ -1,0 +1,27 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# reserve an external IP address for the load balancer
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
+metadata:
+  name: workload-name-external-ip # kpt-set: ${workload-name}-external-ip
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: workload-name-external-ip # kpt-set: ${workload-name}-external-ip
+  description: external IP for workload-name # kpt-set: external IP for ${workload-name}
+  addressType: EXTERNAL
+  ipVersion: IPV4
+  location: global

--- a/examples/landing-zone-v2/tier3/external-load-balancer/backend-service.yaml
+++ b/examples/landing-zone-v2/tier3/external-load-balancer/backend-service.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 #########
 # create the backend service to attach to an existing mig and cloud armor policy
+# also configure CDN defaults
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeBackendService
 metadata:

--- a/examples/landing-zone-v2/tier3/external-load-balancer/backend-service.yaml
+++ b/examples/landing-zone-v2/tier3/external-load-balancer/backend-service.yaml
@@ -1,0 +1,59 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# create the backend service to attach to an existing mig and cloud armor policy
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeBackendService
+metadata:
+  name: workload-name-backend-service # kpt-set: ${workload-name}-backend-service
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: workload-name-backend-service # kpt-set: ${workload-name}-backend-service
+  # set a mig created from tier4 as backend
+  backend:
+    - balancingMode: RATE
+      capacityScaler: 0.9
+      maxRate: 10000
+      group:
+        instanceGroupRef:
+          # when using a MIG, the external ref must be used and is pointing to its 'instanceGroup' value
+          external: https://www.googleapis.com/compute/beta/projects/project-id/zones/northamerica-northeast1-a/instanceGroups/workload-name-instance-group-manager # kpt-set: https://www.googleapis.com/compute/beta/projects/${project-id}/zones/northamerica-northeast1-a/instanceGroups/${workload-name}-instance-group-manager
+  cdnPolicy:
+    cacheKeyPolicy:
+      includeHost: true
+      includeProtocol: true
+      includeQueryString: true
+    cacheMode: CACHE_ALL_STATIC
+    clientTtl: 3600
+    defaultTtl: 3600
+    maxTtl: 86400
+    signedUrlCacheMaxAgeSec: 0
+  connectionDrainingTimeoutSec: 300
+  healthChecks:
+    - healthCheckRef:
+        name: workload-name-health-check-http # kpt-set: ${workload-name}-health-check-http
+  loadBalancingScheme: EXTERNAL_MANAGED
+  localityLbPolicy: ROUND_ROBIN
+  location: global
+  logConfig:
+    enable: true
+    sampleRate: 1
+  portName: http
+  protocol: HTTP
+  # set as target to an existing cloud armor policy
+  securityPolicyRef:
+    name: workload-name-security-policy # kpt-set: ${workload-name}-security-policy
+  sessionAffinity: NONE
+  timeoutSec: 30

--- a/examples/landing-zone-v2/tier3/external-load-balancer/elb.yaml
+++ b/examples/landing-zone-v2/tier3/external-load-balancer/elb.yaml
@@ -1,0 +1,27 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# create the external load balancer
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeURLMap
+metadata:
+  name: workload-name-elb # kpt-set: ${workload-name}-elb
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: workload-name-elb # kpt-set: ${workload-name}-elb
+  defaultService:
+    backendServiceRef:
+      name: workload-name-backend-service # kpt-set: ${workload-name}-backend-service
+  location: global

--- a/examples/landing-zone-v2/tier3/external-load-balancer/elb.yaml
+++ b/examples/landing-zone-v2/tier3/external-load-balancer/elb.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# create the external load balancer
+# create the external load balancer's URL map
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeURLMap
 metadata:

--- a/examples/landing-zone-v2/tier3/external-load-balancer/firewall.yaml
+++ b/examples/landing-zone-v2/tier3/external-load-balancer/firewall.yaml
@@ -1,0 +1,36 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# fw rule for lb health check
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeFirewall
+metadata:
+  name: project-id-workload-name-lb-health-check # kpt-set: ${project-id}-${workload-name}-lb-health-check
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+spec:
+  resourceID: project-id-workload-name-lb-health-check # kpt-set: ${project-id}-${workload-name}-lb-health-check
+  allow:
+    - protocol: tcp
+      ports:
+        - "80"
+  networkRef:
+    name: host-project-id-global-standard-vpc # kpt-set: ${host-project-id}-global-standard-vpc
+    namespace: client-name-networking # kpt-set: ${client-name}-networking
+  sourceRanges:
+    - "35.191.0.0/16"
+    - "130.211.0.0/22"
+  targetServiceAccounts:
+    - name: workload-name-sa # kpt-set: ${workload-name}-sa
+      namespace: project-id-tier4 # kpt-set: ${project-id}-tier4

--- a/examples/landing-zone-v2/tier3/external-load-balancer/forwarding-rule.yaml
+++ b/examples/landing-zone-v2/tier3/external-load-balancer/forwarding-rule.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# the load balancer's forwarding rule
+# an org policy exception may be required depending on the loadBalancingScheme
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeForwardingRule
+metadata:
+  name: workload-name-forwarding-rule # kpt-set: ${workload-name}-forwarding-rule
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: workload-name-forwarding-rule # kpt-set: ${workload-name}-forwarding-rule
+  ipAddress:
+    addressRef:
+      name: workload-name-external-ip # kpt-set: ${workload-name}-external-ip
+  ipProtocol: TCP
+  loadBalancingScheme: EXTERNAL_MANAGED
+  location: global
+  portRange: 80-80
+  target:
+    targetHTTPProxyRef:
+      name: workload-name-target-http-proxy # kpt-set: ${workload-name}-target-http-proxy

--- a/examples/landing-zone-v2/tier3/external-load-balancer/health-check.yaml
+++ b/examples/landing-zone-v2/tier3/external-load-balancer/health-check.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# the backend service health check
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeHealthCheck
+metadata:
+  name: workload-name-health-check-http # kpt-set: ${workload-name}-health-check-http
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: workload-name-health-check-http # kpt-set: ${workload-name}-health-check-http
+  checkIntervalSec: 5
+  healthyThreshold: 2
+  location: global
+  tcpHealthCheck:
+    port: 80
+    proxyHeader: NONE
+  timeoutSec: 5
+  unhealthyThreshold: 3

--- a/examples/landing-zone-v2/tier3/external-load-balancer/target-http-proxy.yaml
+++ b/examples/landing-zone-v2/tier3/external-load-balancer/target-http-proxy.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# the target proxy for the forwarding rule
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeTargetHTTPProxy
+metadata:
+  name: workload-name-target-http-proxy # kpt-set: ${workload-name}-target-http-proxy
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: workload-name-target-http-proxy # kpt-set: ${workload-name}-target-http-proxy
+  location: global
+  urlMapRef:
+    name: workload-name-elb # kpt-set: ${workload-name}-elb

--- a/examples/landing-zone-v2/tier3/firewall-policy-rules/README.md
+++ b/examples/landing-zone-v2/tier3/firewall-policy-rules/README.md
@@ -1,0 +1,9 @@
+# Firewall Policy Rules
+
+Example to create firewall policy rules.
+
+It's important to keep track and modify the priority numbers to avoid issues.  Each project could be assigned a range.
+
+## IAM
+
+The `tier3-sa` account has permissions to create rules on the client's `standard/applications-infrastructure` folder firewall policy.

--- a/examples/landing-zone-v2/tier3/firewall-policy-rules/allow-egress-fqdns.yaml
+++ b/examples/landing-zone-v2/tier3/firewall-policy-rules/allow-egress-fqdns.yaml
@@ -17,8 +17,7 @@
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeFirewallPolicyRule
 metadata:
-  name: project-id-fwpol-edit-name-here # kpt-set: ${project-id}-fwpol-edit-name-here
-  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  name: project-id-fwpol-workload-name # kpt-set: ${project-id}-fwpol-${workload-name}
 spec:
   action: "allow"
   description: "allow access to example.com"
@@ -34,9 +33,11 @@ spec:
         ports:
           - "80"
           - "443"
+    # ideally the range should be smaller than this example
     srcIPRanges:
       - "10.0.0.0/8"
+    # add a list of destination fqdns below
     destFqdns:
       - "example.com"
-  # IMPORTANT to set a proper priority
+  # IMPORTANT to set a proper priority, each project should have a reserved range
   priority: 5050

--- a/examples/landing-zone-v2/tier3/remote-access-to-gce/README.md
+++ b/examples/landing-zone-v2/tier3/remote-access-to-gce/README.md
@@ -1,0 +1,41 @@
+# Remote SSH to Compute Engine
+
+This example creates a firewall rule in the host project to allow SSH access to Google Compute Engine via IAP.
+
+## IAM
+The following permissions are required on the project for group(s) of users who need access:
+
+```yaml
+# iam-iap.yaml
+# Grant GCP role IAP-Secured Tunnel User to instance-admin
+# 'instance-admin' can be added to setters.yaml, or replace member values below
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: instance-admin-iaptunnelresourceaccessor-permissions
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: project-id # kpt-set: ${project-id}
+  role: roles/iap.tunnelResourceAccessor
+  member: "group:group@domain.com" # kpt-set: ${instance-admin}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: instance-admin-computeinstanceadmin-permissions
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: project-id # kpt-set: ${project-id}
+  role: roles/compute.instanceAdmin.v1
+  member: "group:group@domain.com" # kpt-set: ${instance-admin}
+```

--- a/examples/landing-zone-v2/tier3/remote-access-to-gce/firewall-iap.yaml
+++ b/examples/landing-zone-v2/tier3/remote-access-to-gce/firewall-iap.yaml
@@ -1,0 +1,36 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# IAP to GCE workload service account
+# IAM permissions are also required
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeFirewall
+metadata:
+  name: project-id-workload-name-iap-ssh # kpt-set: ${project-id}-${workload-name}-iap-ssh
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+spec:
+  resourceID: project-id-workload-name-iap-ssh # kpt-set: ${project-id}-${workload-name}-iap-ssh
+  allow:
+    - protocol: tcp
+      ports:
+        - "22"
+  networkRef:
+    name: host-project-id-global-standard-vpc # kpt-set: ${host-project-id}-global-standard-vpc
+    namespace: client-name-networking # kpt-set: ${client-name}-networking
+  sourceRanges:
+    - "35.235.240.0/20"
+  targetServiceAccounts:
+    - name: workload-name-sa # kpt-set: ${workload-name}-sa
+      namespace: project-id-tier4 # kpt-set: ${project-id}-tier4

--- a/examples/landing-zone-v2/tier4/managed-instance-group/README.md
+++ b/examples/landing-zone-v2/tier4/managed-instance-group/README.md
@@ -3,7 +3,38 @@
 This example creates a simple managed instance group for an debian instance template with nginx.
 
 ## IAM
-The following permissions are required on the projects' allowed subnets until the [config connector resource](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeinstancegroupmanager) allows for specifying the MIG to use a specific service account when creating VMs. Currently, the `spec.serviceAccountRef` throws an error `Invalid value for field ''resource.serviceAccount'': ''tier4-sa@project-id.iam.gserviceaccount.com''. service account support is not yet available, invalid'`
+These permissions are required for the tier4-sa.  They can be granted from tier3.
+
+```yaml
+# Grant GCP roles to tier4-sa GCP SA
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata:
+  name: project-id-tier4-sa-permissions # kpt-set: ${project-id}-tier4-sa-permissions
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    kind: Project
+    external: projects/project-id # kpt-set: projects/${project-id}
+  bindings:
+    # to manage service accounts
+    - role: roles/iam.serviceAccountAdmin
+      members:
+        - member: "serviceAccount:tier4-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier4-sa@${project-id}.iam.gserviceaccount.com
+    # to use service accounts
+    - role: roles/iam.serviceAccountUser
+      members:
+        - member: "serviceAccount:tier4-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier4-sa@${project-id}.iam.gserviceaccount.com
+    # to manage compute instance resources
+    - role: roles/compute.instanceAdmin
+      members:
+        - member: "serviceAccount:tier4-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier4-sa@${project-id}.iam.gserviceaccount.com
+```
+
+Network user permissions are also required on the projects' allowed subnets until the [config connector resource](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeinstancegroupmanager) allows for specifying the MIG to use a specific service account when creating VMs.
+
+Currently, the `spec.serviceAccountRef` throws an error `Invalid value for field ''resource.serviceAccount'': ''tier4-sa@project-id.iam.gserviceaccount.com''. service account support is not yet available, invalid'`
 
 ```yaml
 # iam-compute.yaml

--- a/examples/landing-zone-v2/tier4/managed-instance-group/README.md
+++ b/examples/landing-zone-v2/tier4/managed-instance-group/README.md
@@ -1,0 +1,40 @@
+# Managed Instance Group
+
+This example creates a simple managed instance group for an debian instance template with nginx.
+
+## IAM
+The following permissions are required on the projects' allowed subnets until the [config connector resource](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeinstancegroupmanager) allows for specifying the MIG to use a specific service account when creating VMs. Currently, the `spec.serviceAccountRef` throws an error `Invalid value for field ''resource.serviceAccount'': ''tier4-sa@project-id.iam.gserviceaccount.com''. service account support is not yet available, invalid'`
+
+```yaml
+# iam-compute.yaml
+# current workaround must be deployed in the repo with 'client-project-setup' (tier2)
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-cloud-services-sa-networkuser-allowed-nane1-subnet-permissions # kpt-set: ${project-id}-cloud-services-sa-networkuser-${allowed-nane1-subnet}-permissions
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    kind: ComputeSubnetwork
+    name: host-project-id-allowed-nane1-subnet # kpt-set: ${host-project-id}-${allowed-nane1-subnet}
+  role: roles/compute.networkUser
+  member: "serviceAccount:REPLACE_WITH_PROJECT_NUMBER@cloudservices.gserviceaccount.com"
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-cloud-services-sa-networkuser-allowed-nane2-subnet-permissions # kpt-set: ${project-id}-cloud-services-sa-networkuser-${allowed-nane2-subnet}-permissions
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    kind: ComputeSubnetwork
+    name: host-project-id-allowed-nane2-subnet # kpt-set: ${host-project-id}-${allowed-nane2-subnet}
+  role: roles/compute.networkUser
+  member: "serviceAccount:REPLACE_WITH_PROJECT_NUMBER@cloudservices.gserviceaccount.com"
+```

--- a/examples/landing-zone-v2/tier4/managed-instance-group/instance-group-manager.yaml
+++ b/examples/landing-zone-v2/tier4/managed-instance-group/instance-group-manager.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Managed Instance Group
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeInstanceGroupManager
+metadata:
+  name: workload-name-instance-group-manager # kpt-set: ${workload-name}-instance-group-manager
+spec:
+  resourceID: workload-name-instance-group-manager # kpt-set: ${workload-name}-instance-group-manager
+  projectRef:
+    external: projects/project-id # kpt-set: projects/${project-id}
+  location: northamerica-northeast1-a
+  instanceTemplateRef:
+    name: workload-name-instance-template # kpt-set: ${workload-name}-instance-template
+  namedPorts:
+    - name: http
+      port: 80
+  # this funtionality is not yet available, because of this,
+  # network user permission needs to be granted in the network host project for {project-number}@cloudservices.gserviceaccount.com
+  # serviceAccountRef:
+  #   external: tier4-sa@project-id.iam.gserviceaccount.com # kpt-set: tier4-sa@${project-id}.iam.gserviceaccount.com
+  targetSize: 1

--- a/examples/landing-zone-v2/tier4/managed-instance-group/instance-template.yaml
+++ b/examples/landing-zone-v2/tier4/managed-instance-group/instance-template.yaml
@@ -1,0 +1,75 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Instance template
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeInstanceTemplate
+metadata:
+  name: workload-name-instance-template # kpt-set: ${workload-name}-instance-template
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: workload-name-instance-template # kpt-set: ${workload-name}-instance-template
+  confidentialInstanceConfig:
+    enableConfidentialCompute: false
+  disk:
+    - autoDelete: true
+      boot: true
+      deviceName: persistent-disk-0
+      diskSizeGb: 10
+      diskType: pd-balanced
+      interface: SCSI
+      mode: READ_WRITE
+      sourceImageRef:
+        external: projects/debian-cloud/global/images/debian-11-bullseye-v20230509
+      type: PERSISTENT
+  machineType: e2-small
+  metadata:
+    - key: enable-oslogin
+      value: "true"
+    # an example to install nginx on startup
+    - key: startup-script
+      value: |
+        #! /bin/bash
+        apt update
+        apt -y install nginx
+        cat <<EOF > /var/www/html/index.html
+        <html><body><p>Linux startup script added directly.</p></body></html>
+        EOF
+  networkInterface:
+    - name: nic0
+      networkRef:
+        name: host-project-id-global-standard-vpc # kpt-set: ${host-project-id}-global-standard-vpc
+        namespace: client-name-networking # kpt-set: ${client-name}-networking
+      stackType: IPV4_ONLY
+      subnetworkProject: host-project-id # kpt-set: ${host-project-id}
+      subnetworkRef:
+        name: host-project-id-nane1-standard-unclassified-snet # kpt-set: ${host-project-id}-nane1-standard-unclassified-snet
+        namespace: client-name-networking # kpt-set: ${client-name}-networking
+  region: northamerica-northeast1
+  reservationAffinity:
+    type: ANY_RESERVATION
+  scheduling:
+    automaticRestart: true
+    onHostMaintenance: MIGRATE
+    provisioningModel: STANDARD
+  serviceAccount:
+    scopes:
+      - https://www.googleapis.com/auth/cloud-platform
+    serviceAccountRef:
+      name: workload-name-sa # kpt-set: ${workload-name}-sa
+  shieldedInstanceConfig:
+    enableIntegrityMonitoring: true
+    enableSecureBoot: true
+    enableVtpm: true

--- a/examples/landing-zone-v2/tier4/managed-instance-group/service-account.yaml
+++ b/examples/landing-zone-v2/tier4/managed-instance-group/service-account.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# GCP SA
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: workload-name-sa # kpt-set: ${workload-name}-sa
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  displayName: workload-name-sa # kpt-set: ${workload-name}-sa

--- a/solutions/client-landing-zone/README.md
+++ b/solutions/client-landing-zone/README.md
@@ -17,7 +17,7 @@ Package to create a client's folder hierarchy, logging resources and a network h
 | allowed-os-update-domains          | ["debian.map.fastlydns.net", "debian.org", "deb.debian.org", "ubuntu.com", "packages.cloud.google.com", "security.ubuntu.com", "northamerica-northeast1.gce.archive.ubuntu.com", "northamerica-northeast2.gce.archive.ubuntu.com"] | array |     1 |
 | client-billing-id                  | AAAAAA-BBBBBB-CCCCCC                                                                                                                                                                                                               | str   |     1 |
 | client-folderviewer                | group:client1@example.com                                                                                                                                                                                                          | str   |     1 |
-| client-name                        | client1                                                                                                                                                                                                                            | str   |   168 |
+| client-name                        | client1                                                                                                                                                                                                                            | str   |   172 |
 | denied-sanctioned-countries        | ["CU", "IR", "KP", "SY"]                                                                                                                                                                                                           | array |     1 |
 | firewall-egress-allow-all-internal | [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]                                                                                                                                                                                        | array |     3 |
 | host-project-id                    | net-host-project-12345                                                                                                                                                                                                             | str   |   111 |
@@ -104,6 +104,7 @@ This package has no sub-packages.
 | client-folder/standard/firewall-policy/rules/network-isolation.yaml                                                                     | compute.cnrm.cloud.google.com/v1beta1         | ComputeFirewallPolicyRule        | client-name-standard-fwpol-isolate-protected-a-fwr                                         | client-name-networking |
 | client-folder/standard/firewall-policy/rules/network-isolation.yaml                                                                     | compute.cnrm.cloud.google.com/v1beta1         | ComputeFirewallPolicyRule        | client-name-standard-fwpol-isolate-protected-b-fwr                                         | client-name-networking |
 | client-folder/standard/folder.yaml                                                                                                      | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                           | standard                                                                                   | client-name-hierarchy  |
+| client-folder/standard/org-policies/exceptions/compute-restrict-load-balancer-creation-for-types.yaml                                   | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy            | compute-restrict-load-balancer-creation-for-types-except-standard-folder                   | policies               |
 | logging-project/cloud-logging-bucket.yaml                                                                                               | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogBucket                 | platform-and-component-client-name-log-bucket                                              | logging                |
 | logging-project/project-iam.yaml                                                                                                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy                 | platform-and-component-log-client-name-bucket-writer-permissions                           | projects               |
 
@@ -143,7 +144,7 @@ This package has no sub-packages.
 
 1.  Move into the local package:
     ```shell
-    cd ".//solutions/client-landing-zone/"
+    cd "./solutions/client-landing-zone/"
     ```
 
 1.  Edit the function config file(s):

--- a/solutions/client-landing-zone/client-folder/standard/org-policies/exceptions/compute-restrict-load-balancer-creation-for-types.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/org-policies/exceptions/compute-restrict-load-balancer-creation-for-types.yaml
@@ -1,0 +1,47 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+#
+# GCP Organization Policies
+# Org policies that correspond with a Guardrail will contain a label indicating what Guardrails it helps in enforcing
+# https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints
+#
+# Constraint: constraints/compute.restrictLoadBalancerCreationForTypes
+#
+# This list constraint defines
+# the set of load balancer types which can be created for an organization,
+# folder, or project. Every load balancer type to be allowed or denied must be listed explicitly.
+#
+# Options: INTERNAL, EXTERNAL, INTERNAL_TCP_UDP, INTERNAL_HTTP_HTTPS, EXTERNAL_NETWORK_TCP_UDP
+# EXTERNAL_TCP_PROXY, EXTERNAL_SSL_PROXY, EXTERNAL_HTTP_HTTPS, EXTERNAL_MANAGED_HTTP_HTTPS
+#
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: ResourceManagerPolicy
+metadata:
+  name: compute-restrict-load-balancer-creation-for-types-except-standard-folder
+  namespace: policies
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-hierarchy/Folder/standard # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-hierarchy/Folder/standard
+  labels:
+    guardrail: "true"
+    guardrail-enforced: guardrail-06
+spec:
+  constraint: "constraints/compute.restrictLoadBalancerCreationForTypes"
+  listPolicy:
+    allow:
+      all: true
+  folderRef:
+    name: standard
+    namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy

--- a/solutions/client-project-setup/README.md
+++ b/solutions/client-project-setup/README.md
@@ -12,20 +12,22 @@ Package to create a client's project, 2 project scoped namespaces for its resour
 
 ## Setters
 
-|             Name             |              Value              | Type | Count |
-|------------------------------|---------------------------------|------|-------|
-| client-management-project-id | client-management-project-12345 | str  |     1 |
-| client-name                  | client1                         | str  |    50 |
-| host-project-id              | net-host-project-12345          | str  |     5 |
-| management-namespace         | config-control                  | str  |     8 |
-| management-project-id        | management-project-12345        | str  |     2 |
-| org-id                       |                      0000000000 | str  |     2 |
-| project-billing-id           | AAAAAA-BBBBBB-CCCCCC            | str  |     1 |
-| project-id                   | client-project-12345            | str  |    88 |
-| project-parent-folder        | project-parent-folder           | str  |     2 |
-| repo-branch                  | main                            | str  |     1 |
-| repo-dir                     | csync/deploy/env                | str  |     1 |
-| repo-url                     | git-repo-to-observe             | str  |     1 |
+|             Name             |               Value                | Type | Count |
+|------------------------------|------------------------------------|------|-------|
+| allowed-nane1-subnet         | nane1-standard-classification-snet | str  |     2 |
+| allowed-nane2-subnet         | nane2-standard-classification-snet | str  |     2 |
+| client-management-project-id | client-management-project-12345    | str  |     1 |
+| client-name                  | client1                            | str  |    50 |
+| host-project-id              | net-host-project-12345             | str  |     5 |
+| management-namespace         | config-control                     | str  |     8 |
+| management-project-id        | management-project-12345           | str  |     2 |
+| org-id                       |                         0000000000 | str  |     2 |
+| project-billing-id           | AAAAAA-BBBBBB-CCCCCC               | str  |     1 |
+| project-id                   | client-project-12345               | str  |    87 |
+| project-parent-folder        | project-parent-folder              | str  |     2 |
+| repo-branch                  | main                               | str  |     1 |
+| repo-dir                     | csync/deploy/env                   | str  |     1 |
+| repo-url                     | git-repo-to-observe                | str  |     1 |
 
 ## Sub-packages
 
@@ -47,8 +49,8 @@ This package has no sub-packages.
 | namespaces/project-id-tier3.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | cnrm-viewer-project-id-tier3                                                | project-id-tier4           |
 | namespaces/project-id-tier3.yaml | rbac.authorization.k8s.io/v1                  | RoleBinding                    | syncs-repo                                                                  | project-id-tier3           |
 | namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount              | project-id-tier4-sa                                                         | client-name-config-control |
-| namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier4-sa-editor-project-id-permissions                           | client-name-projects       |
-| namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier4-sa-networkuser-host-project-id-permissions                 | client-name-projects       |
+| namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier4-sa-networkuser-allowed-nane1-subnet-permissions            | client-name-networking     |
+| namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier4-sa-networkuser-allowed-nane2-subnet-permissions            | client-name-networking     |
 | namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier4-sa-instanceadmin-project-id-permissions                    | client-name-projects       |
 | namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy               | project-id-tier4-sa-workload-identity-binding                               | client-name-config-control |
 | namespaces/project-id-tier4.yaml | v1                                            | Namespace                      | project-id-tier4                                                            |                            |
@@ -89,7 +91,7 @@ This package has no sub-packages.
 
 1.  Move into the local package:
     ```shell
-    cd ".//solutions/client-project-setup/"
+    cd "./solutions/client-project-setup/"
     ```
 
 1.  Edit the function config file(s):

--- a/solutions/client-project-setup/README.md
+++ b/solutions/client-project-setup/README.md
@@ -17,13 +17,13 @@ Package to create a client's project, 2 project scoped namespaces for its resour
 | allowed-nane1-subnet         | nane1-standard-classification-snet | str  |     2 |
 | allowed-nane2-subnet         | nane2-standard-classification-snet | str  |     2 |
 | client-management-project-id | client-management-project-12345    | str  |     1 |
-| client-name                  | client1                            | str  |    50 |
+| client-name                  | client1                            | str  |    48 |
 | host-project-id              | net-host-project-12345             | str  |     5 |
 | management-namespace         | config-control                     | str  |     8 |
 | management-project-id        | management-project-12345           | str  |     2 |
 | org-id                       |                         0000000000 | str  |     2 |
 | project-billing-id           | AAAAAA-BBBBBB-CCCCCC               | str  |     1 |
-| project-id                   | client-project-12345               | str  |    87 |
+| project-id                   | client-project-12345               | str  |    83 |
 | project-parent-folder        | project-parent-folder              | str  |     2 |
 | repo-branch                  | main                               | str  |     1 |
 | repo-dir                     | csync/deploy/env                   | str  |     1 |
@@ -51,7 +51,6 @@ This package has no sub-packages.
 | namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount              | project-id-tier4-sa                                                         | client-name-config-control |
 | namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier4-sa-networkuser-allowed-nane1-subnet-permissions            | client-name-networking     |
 | namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier4-sa-networkuser-allowed-nane2-subnet-permissions            | client-name-networking     |
-| namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember                | project-id-tier4-sa-instanceadmin-project-id-permissions                    | client-name-projects       |
 | namespaces/project-id-tier4.yaml | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy               | project-id-tier4-sa-workload-identity-binding                               | client-name-config-control |
 | namespaces/project-id-tier4.yaml | v1                                            | Namespace                      | project-id-tier4                                                            |                            |
 | namespaces/project-id-tier4.yaml | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext         | configconnectorcontext.core.cnrm.cloud.google.com                           | project-id-tier4           |

--- a/solutions/client-project-setup/namespaces/project-id-tier4.yaml
+++ b/solutions/client-project-setup/namespaces/project-id-tier4.yaml
@@ -26,41 +26,37 @@ spec:
   resourceID: tier4-sa
   displayName: tier4-sa
 ---
-# Grant GCP role Editor to GCP SA
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# Grant GCP role Network User to GCP SA on nane1 subnet
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: project-id-tier4-sa-editor-project-id-permissions # kpt-set: ${project-id}-tier4-sa-editor-${project-id}-permissions
-  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  name: project-id-tier4-sa-networkuser-allowed-nane1-subnet-permissions # kpt-set: ${project-id}-tier4-sa-networkuser-${allowed-nane1-subnet}-permissions
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
     config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
 spec:
   resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Project
-    name: project-id # kpt-set: ${project-id}
-  role: roles/editor
+    apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    kind: ComputeSubnetwork
+    name: host-project-id-allowed-nane1-subnet # kpt-set: ${host-project-id}-${allowed-nane1-subnet}
+  role: roles/compute.networkUser
   member: "serviceAccount:tier4-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier4-sa@${project-id}.iam.gserviceaccount.com
 ---
-# Grant GCP role Network User to GCP SA on Host Project
-# https://cloud.google.com/iam/docs/job-functions/networking
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# Grant GCP role Network User to GCP SA on nane2 subnet
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: project-id-tier4-sa-networkuser-host-project-id-permissions # kpt-set: ${project-id}-tier4-sa-networkuser-${host-project-id}-permissions
-  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  name: project-id-tier4-sa-networkuser-allowed-nane2-subnet-permissions # kpt-set: ${project-id}-tier4-sa-networkuser-${allowed-nane2-subnet}-permissions
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
     config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
 spec:
-  # TODO: revisit to potentially grant networkUser on a subnet instead of project
   resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Project
-    name: host-project-id # kpt-set: ${host-project-id}
+    apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    kind: ComputeSubnetwork
+    name: host-project-id-allowed-nane2-subnet # kpt-set: ${host-project-id}-${allowed-nane2-subnet}
   role: roles/compute.networkUser
   member: "serviceAccount:tier4-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier4-sa@${project-id}.iam.gserviceaccount.com
 ---

--- a/solutions/client-project-setup/namespaces/project-id-tier4.yaml
+++ b/solutions/client-project-setup/namespaces/project-id-tier4.yaml
@@ -60,25 +60,6 @@ spec:
   role: roles/compute.networkUser
   member: "serviceAccount:tier4-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier4-sa@${project-id}.iam.gserviceaccount.com
 ---
-# Grant GCP role Compute Instance Admin to GCP SA
-# https://cloud.google.com/iam/docs/job-functions/networking
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
-metadata:
-  name: project-id-tier4-sa-instanceadmin-project-id-permissions # kpt-set: ${project-id}-tier4-sa-instanceadmin-${project-id}-permissions
-  namespace: client-name-projects # kpt-set: ${client-name}-projects
-  annotations:
-    cnrm.cloud.google.com/ignore-clusterless: "true"
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
-spec:
-  resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Project
-    name: project-id # kpt-set: ${project-id}
-  role: roles/compute.instanceAdmin
-  member: "serviceAccount:tier4-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier4-sa@${project-id}.iam.gserviceaccount.com
----
 # K8S SA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy

--- a/solutions/client-project-setup/setters.yaml
+++ b/solutions/client-project-setup/setters.yaml
@@ -65,6 +65,10 @@ data:
   # ID of existing Shared VPC host project to associate
   host-project-id: net-host-project-12345
   #
+  # the nane1 and nane2 subnets to grant network user permissions, replace 'classification' with appropriate values
+  allowed-nane1-subnet: nane1-standard-classification-snet
+  allowed-nane2-subnet: nane2-standard-classification-snet
+  #
   ##########################
   # Project
   ##########################

--- a/solutions/client-setup/README.md
+++ b/solutions/client-setup/README.md
@@ -15,8 +15,8 @@ Package to setup a client's namespaces, folder, management project and root sync
 |             Name             |              Value              | Type | Count |
 |------------------------------|---------------------------------|------|-------|
 | client-billing-id            | AAAAAA-BBBBBB-CCCCCC            | str  |     1 |
-| client-management-project-id | client-management-project-12345 | str  |   102 |
-| client-name                  | client1                         | str  |   120 |
+| client-management-project-id | client-management-project-12345 | str  |   103 |
+| client-name                  | client1                         | str  |   122 |
 | environment                  | env                             | str  |     1 |
 | management-namespace         | config-control                  | str  |    25 |
 | management-project-id        | management-project-12345        | str  |     5 |
@@ -50,6 +50,7 @@ This package has no sub-packages.
 | namespaces/client-name-hierarchy.yaml            | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com                                      | client-name-hierarchy      |
 | namespaces/client-name-hierarchy.yaml            | rbac.authorization.k8s.io/v1                  | RoleBinding            | allow-resource-reference-from-projects                                                 | client-name-hierarchy      |
 | namespaces/client-name-hierarchy.yaml            | rbac.authorization.k8s.io/v1                  | RoleBinding            | allow-resource-reference-from-client-name-hierarchy                                    | hierarchy                  |
+| namespaces/client-name-hierarchy.yaml            | rbac.authorization.k8s.io/v1                  | RoleBinding            | allow-client-name-hierarchy-resource-reference-from-policies                           | client-name-hierarchy      |
 | namespaces/client-name-logging.yaml              | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount      | client-name-logging-sa                                                                 | client-name-config-control |
 | namespaces/client-name-logging.yaml              | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-logging-sa-logadmin-permissions                                            | hierarchy                  |
 | namespaces/client-name-logging.yaml              | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-logging-sa-bigqueryadmin-permissions                                       | hierarchy                  |
@@ -116,7 +117,7 @@ This package has no sub-packages.
 
 1.  Move into the local package:
     ```shell
-    cd ".//solutions/client-setup/"
+    cd "./solutions/client-setup/"
     ```
 
 1.  Edit the function config file(s):

--- a/solutions/client-setup/namespaces/client-name-hierarchy.yaml
+++ b/solutions/client-setup/namespaces/client-name-hierarchy.yaml
@@ -117,3 +117,21 @@ subjects:
   - name: cnrm-controller-manager-client-name-hierarchy # kpt-set: cnrm-controller-manager-${client-name}-hierarchy
     namespace: cnrm-system
     kind: ServiceAccount
+---
+# Grant viewer role on the client-name-hierarchy namespace to policies K8S SA
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-client-name-hierarchy-resource-reference-from-policies # kpt-set: allow-${client-name}-hierarchy-resource-reference-from-policies
+  namespace: client-name-hierarchy # kpt-set: ${client-name}-hierarchy
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
+roleRef:
+  name: cnrm-viewer
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: cnrm-controller-manager-policies
+    namespace: cnrm-system
+    kind: ServiceAccount


### PR DESCRIPTION
closes #391 

cleanup permissions, org policies and provide examples to deploy cloud armor policies

`client-setup`
- add client name hierarchy viewer to policies

`client-landing-zone`
- add org policy exception for lb types on the standard folder

`client-project-setup`
- tier4-sa: remove editor role (too much overlap with security roles) and compute instance admin
- tier4-sa: move network user permissions from host project to subnets

`examples`
- add tier3/cloud-armor
- add tier3/external-load-balancer
- add tier3/remote-access-to-gce
- add tier4/managed-instance-group
