### PR TITLE
remove alpha api from logging settings describe/update in docs/landing-zone-v2/README.md 

### DIFF
--- a/docs/landing-zone-v2/README.md
+++ b/docs/landing-zone-v2/README.md
@@ -140,10 +140,10 @@ To deploy this Landing Zone you will need to:
 
     ```shell
     # Validate if a storageLocation is defined for the organization
-    gcloud alpha logging settings describe --organization=${ORG_ID}
+    gcloud logging settings describe --organization=${ORG_ID}
 
     # Modify the default logging storage location
-    gcloud alpha logging settings update --organization=$ORG_ID --storage-location=$REGION
+    gcloud logging settings update --organization=$ORG_ID --storage-location=$REGION
     ```
 
 1. Create the Organization level Access Context Manager policy


### PR DESCRIPTION
As part of ongoing automation/review #296
Update below to remove the alpha api
https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/docs/landing-zone-v2/README.md#initial-organization-configuration

Testing
```
root_@cloudshell:~/kcc-kls/pubsec-declarative-toolkit/solutions/landing-zone-v2 (kcc-kls)$ gcloud logging settings describe --organization=${ORG_ID}
kmsServiceAccountId: cmek-o156483884993@gcp-sa-logging.iam.gserviceaccount.com
loggingServiceAccountId: service-org-156483884993@gcp-sa-logging.iam.gserviceaccount.com
name: organizations/156483884993/settings
storageLocation: northamerica-northeast1

root_@cloudshell:~/kcc-kls/pubsec-declarative-toolkit/solutions/landing-zone-v2 (kcc-kls)$ gcloud logging settings update --organization=$ORG_ID --storage-location=$REGION
kmsServiceAccountId: cmek-o156483884993@gcp-sa-logging.iam.gserviceaccount.com
loggingServiceAccountId: service-org-156483884993@gcp-sa-logging.iam.gserviceaccount.com
name: organizations/156483884993/settings
storageLocation: northamerica-northeast2
root_@cloudshell:~/kcc-kls/pubsec-declarative-toolkit/solutions/landing-zone-v2 (kcc-kls)$ gcloud logging settings describe --organization=${ORG_ID}
kmsServiceAccountId: cmek-o156483884993@gcp-sa-logging.iam.gserviceaccount.com
loggingServiceAccountId: service-org-156483884993@gcp-sa-logging.iam.gserviceaccount.com
name: organizations/156483884993/settings
storageLocation: northamerica-northeast2
```