### PR TITLE
fix: adding missing dns project id setter

### DIFF
--- a/solutions/client-setup/README.md
+++ b/solutions/client-setup/README.md
@@ -15,13 +15,14 @@ Package to setup a client's namespaces, folder, management project and root sync
 |             Name             |              Value              | Type | Count |
 |------------------------------|---------------------------------|------|-------|
 | client-billing-id            | AAAAAA-BBBBBB-CCCCCC            | str  |     1 |
-| client-management-project-id | client-management-project-12345 | str  |   103 |
-| client-name                  | client1                         | str  |   122 |
+| client-management-project-id | client-management-project-12345 | str  |   105 |
+| client-name                  | client1                         | str  |   124 |
+| dns-project-id               | dns-project-12345               | str  |     1 |
 | environment                  | env                             | str  |     1 |
 | management-namespace         | config-control                  | str  |    25 |
 | management-project-id        | management-project-12345        | str  |     5 |
 | management-project-number    |                      0000000000 | str  |     1 |
-| org-id                       |                      0000000000 | str  |     2 |
+| org-id                       |                      0000000000 | str  |     3 |
 | repo-branch                  | main                            | str  |     1 |
 | repo-dir                     | csync/deploy/env                | str  |     1 |
 | repo-url                     | git-repo-to-observe             | str  |     1 |
@@ -69,6 +70,7 @@ This package has no sub-packages.
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-networkadmin-permissions                                     | hierarchy                  |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-security-permissions                                         | hierarchy                  |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-dns-permissions                                              | hierarchy                  |
+| namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-tier2-dns-record-admin-permission                            | projects                   |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-service-control-permissions                                  | hierarchy                  |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-xpnadmin-permissions                                         | config-control             |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-servicedirectoryeditor-permissions                           | hierarchy                  |

--- a/solutions/client-setup/setters.yaml
+++ b/solutions/client-setup/setters.yaml
@@ -80,5 +80,10 @@ data:
   repo-dir: csync/deploy/env
   #
   ##########################
+  # DNS
+  ##########################
+  # dns project id created in core-landing-zone
+  dns-project-id: dns-project-12345
+  ##########################
   # End of Configurations
   ##########################


### PR DESCRIPTION
Addressing missing `dns-project-id` setter. 

This is required to allow the following resource to be created [client-name-networking.yaml](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/client-setup/namespaces/client-name-networking.yaml) 

```yaml
# Grant GCP role Tier2 DNS Record Admin to GCP SA on Core DNS Project
apiVersion: iam.cnrm.cloud.google.com/v1beta1
kind: IAMPolicyMember
...
```