### PR TITLE
fix: fixing DNS tier3 example

### DIFF
--- a/examples/landing-zone-v2/tier3/dns/address.yaml
+++ b/examples/landing-zone-v2/tier3/dns/address.yaml
@@ -16,7 +16,7 @@
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeAddress
 metadata:
-  name: workload-name-external-ip # kpt-set: ${workload-name}-external-ip
+  name: workload-name-compute-address # kpt-set: ${workload-name}-compute-address
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:

--- a/examples/landing-zone-v2/tier3/dns/dns.yaml
+++ b/examples/landing-zone-v2/tier3/dns/dns.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# create a DNS A record referencing a tier 4 external IP address
+# create a DNS A record referencing a tier 3 external IP address
 # SC-22
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSRecordSet
@@ -21,13 +21,12 @@ metadata:
   annotations:
     cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
 spec:
-  name: dns-name # kpt-set: ${dns-name}
+  name: "dns-name" # kpt-set: ${dns-name}
   type: "A"
   ttl: 300
   managedZoneRef:
     name: client-name-standard-public-dns # kpt-set: ${client-name}-standard-public-dns
     namespace: client-name-networking # kpt-set: ${client-name}-networking
   rrdatasRefs:
-    - name: client-name-compute-address # kpt-set: ${client-name}-compute-address
+    - name: client-name-compute-address # kpt-set: ${workload-name}-compute-address
       kind: ComputeAddress
-      namespace: project-id-tier4 # kpt-set: ${project-id}-tier4

--- a/examples/landing-zone-v2/tier3/dns/dns.yaml
+++ b/examples/landing-zone-v2/tier3/dns/dns.yaml
@@ -28,5 +28,5 @@ spec:
     name: client-name-standard-public-dns # kpt-set: ${client-name}-standard-public-dns
     namespace: client-name-networking # kpt-set: ${client-name}-networking
   rrdatasRefs:
-    - name: client-name-compute-address # kpt-set: ${workload-name}-compute-address
+    - name: workload-name-compute-address # kpt-set: ${workload-name}-compute-address
       kind: ComputeAddress


### PR DESCRIPTION
**Fixes**
- adjusting compute address name
- fixing dns spec name, missing double quotes
- fixing rrdatasRefs name
- removing namespace reference to tier 4. We had decided to pair DNS A record and its compute address inside `tier3`