### PR TITLE
fix: remove external depends-on annotation

### DIFF
--- a/solutions/client-project-setup/project.yaml
+++ b/solutions/client-project-setup/project.yaml
@@ -20,7 +20,6 @@ metadata:
   namespace: client-name-projects # kpt-set: ${client-name}-projects
   annotations:
     cnrm.cloud.google.com/auto-create-network: "false"
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-hierarchy/Folder/project-parent-folder # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-hierarchy/Folder/${project-parent-folder}
 spec:
   name: project-id # kpt-set: ${project-id}
   billingAccountRef:


### PR DESCRIPTION
This PR addresses the issue described in #422 by removing the `depends-on` annotation from the project object in `project.yaml`.

This change helps ensure that this package is not trying to reach across `resourceGroups` either in `kpt` or `config-sync`. In `kpt` this would be the resources that are captured in the `kpt live init` command or in `config-sync` the scope of the `root` or `repo` sync objects.

