### PR TITLE
#475 - fix legacy move of lz v2 incoming link

### DIFF
--- a/docs/landing-zone-v2/README.md
+++ b/docs/landing-zone-v2/README.md
@@ -364,7 +364,7 @@ cd pbmm-landingzone
 1. Customize Packages
 
     Review and customize all packages' `setters.yaml` with the unique configuration of your landing zone.  
-    For example "core-landing-zone" will have the same [setters.yaml](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/landing-zone-v2/setters.yaml) as in the repo in the root of the pkg directory.
+    For example "core-landing-zone" will have the same [setters.yaml](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/core-landing-zone/setters.yaml#L41) as in the repo in the root of the pkg directory.
 
 ## <a name='deploy-the-infrastructure-using-gitops'></a>3. Deploy the infrastructure using GitOps
 

--- a/docs/landing-zone-v2/README.md
+++ b/docs/landing-zone-v2/README.md
@@ -366,7 +366,7 @@ cd pbmm-landingzone
 1. Customize Packages
 
     Review and customize all packages' `setters.yaml` with the unique configuration of your landing zone.  
-    For example "core-landing-zone" will have the same [setters.yaml](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/core-landing-zone/setters.yaml#L41) as in the repo in the root of the pkg directory.
+    For example "core-landing-zone" will have the same [setters.yaml](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/core-landing-zone/setters.yaml) as in the repo in the root of the pkg directory.
 
 ### <a name='deploy-the-infrastructure-using-kpt'></a>2b. Deploy the infrastructure using KPT
 This section is an optional dev-oriented alternative to the GitOps approach (which is recommended for production deployments) in the following section 3.


### PR DESCRIPTION
merge this one after the merge and rebase of 
https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/pull/458



An inadvertent result of a sequence of PRs where one merged that moved files that were previously in another spot when the previous linked to them ok.

fix
https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/docs/landing-zone-v2#2-create-your-landing-zone
link
https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/landing-zone-v2/setters.yaml
to
https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/core-landing-zone/setters.yaml
dont need to reference where it actually is - as it is now deprecated in
https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/legacy/landing-zone-v2/setters.yaml

the following
https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/pull/441
was affected by
https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/pull/447

TODO: check all incoming links into files moved into the legacy folder for redirection
see one change in https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/issues/475