### PR TITLE
feat: gke-setup package

### DIFF
--- a/solutions/gke/configconnector/gke-setup/Kptfile
+++ b/solutions/gke/configconnector/gke-setup/Kptfile
@@ -1,0 +1,17 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: gke-setup
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    Landing zone v2 subpackage.
+    Depends on package `client-project-setup`.
+    Deploy this package once per service project.
+
+    Package to prepare a service project for GKE clusters. Permissions are granted onto the host project.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/gke/configconnector/gke-setup/README.md
+++ b/solutions/gke/configconnector/gke-setup/README.md
@@ -1,0 +1,121 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# gke-setup
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+Landing zone v2 subpackage.
+Depends on package `client-project-setup`.
+Deploy this package once per service project.
+
+Package to prepare a service project for GKE clusters. Permissions are granted onto the host project.
+
+## Setters
+
+|             Name             |              Value              | Type | Count |
+|------------------------------|---------------------------------|------|-------|
+| client-management-project-id | client-management-project-12345 | str  |     1 |
+| client-name                  | client1                         | str  |    50 |
+| gke-monitoring-group         | group@example.com               | str  |     1 |
+| host-project-id              | net-host-project-12345          | str  |    10 |
+| org-id                       |                      0000000000 | str  |     3 |
+| project-id                   | project-12345                   | str  |    92 |
+| project-number               |                      0000000000 | str  |     5 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|                    File                     |                 APIVersion                 |             Kind              |                                        Name                                        |      Namespace       |
+|---------------------------------------------|--------------------------------------------|-------------------------------|------------------------------------------------------------------------------------|----------------------|
+| gkehub-feature-acm.yaml                     | gkehub.cnrm.cloud.google.com/v1beta1       | GKEHubFeature                 | project-id-acm-hubfeature                                                          | project-id-tier3     |
+| host-project/project-iam.yaml               | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-cloudservices-sa-networkuser-host-project-id-permissions                | client-name-projects |
+| host-project/project-iam.yaml               | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-container-engine-robot-sa-networkuser-host-project-id-permissions       | client-name-projects |
+| host-project/project-iam.yaml               | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-container-engine-robot-sa-gkefirewall-admin-host-project-id-permissions | client-name-projects |
+| host-project/project-iam.yaml               | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-tier3-sa-tier3-subnetwork-admin-host-project-id-permissions             | client-name-projects |
+| host-project/project-iam.yaml               | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-container-engine-robot-sa-host-servce-agent-host-project-id-permissions | client-name-projects |
+| logging-monitoring/alerts.yaml              | monitoring.cnrm.cloud.google.com/v1beta1   | MonitoringAlertPolicy         | project-id-gke-security-posture-critical-severity-alert                            | client-name-logging  |
+| logging-monitoring/alerts.yaml              | monitoring.cnrm.cloud.google.com/v1beta1   | MonitoringAlertPolicy         | project-id-gke-security-posture-high-severity-alert                                | client-name-logging  |
+| logging-monitoring/alerts.yaml              | monitoring.cnrm.cloud.google.com/v1beta1   | MonitoringAlertPolicy         | project-id-gke-security-posture-medium-severity-alert                              | client-name-logging  |
+| logging-monitoring/alerts.yaml              | monitoring.cnrm.cloud.google.com/v1beta1   | MonitoringAlertPolicy         | project-id-gke-security-posture-low-severity-alert                                 | client-name-logging  |
+| logging-monitoring/alerts.yaml              | monitoring.cnrm.cloud.google.com/v1beta1   | MonitoringAlertPolicy         | project-id-gke-cluster-event-notification-alert                                    | client-name-logging  |
+| logging-monitoring/alerts.yaml              | monitoring.cnrm.cloud.google.com/v1beta1   | MonitoringAlertPolicy         | project-id-gke-cluster-upgrade-alert                                               | client-name-logging  |
+| logging-monitoring/notificationchannel.yaml | monitoring.cnrm.cloud.google.com/v1beta1   | MonitoringNotificationChannel | project-id-gke-monitoring-group-notify                                             | client-name-logging  |
+| logging-monitoring/pubsub.yaml              | pubsub.cnrm.cloud.google.com/v1beta1       | PubSubTopic                   | project-id-gke-cluster-notification-pubsub-topic                                   | client-name-logging  |
+| logging-monitoring/pubsub.yaml              | pubsub.cnrm.cloud.google.com/v1beta1       | PubSubSubscription            | project-id-gke-cluster-notification-pubsub-subscription                            | client-name-logging  |
+| project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-tier3-sa-gke-hub-admin-project-id-permissions                           | client-name-projects |
+| project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-tier3-sa-container-admin-project-id-permissions                         | client-name-projects |
+| project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-tier3-sa-service-agent-project-id-permissions                           | client-name-projects |
+| project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-tier3-sa-kms-admin-project-id-permissions                               | client-name-projects |
+| project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-container-engine-robot-sa-kms-encrypt-decrypt-project-id-permissions    | client-name-projects |
+| project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-tier4-sa-artifactregistry-admin-project-id-permissions                  | client-name-projects |
+| project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-tier4-sa-tier4-secret-manager-admin-project-id-permissions              | client-name-projects |
+| project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | client-name-logging-sa-pubsub-admin-project-id-permissions                         | client-name-projects |
+| project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMAuditConfig                | project-id-data-access-log-config                                                  | client-name-projects |
+| services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-container                                                               | client-name-projects |
+| services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-containersecurity                                                       | client-name-projects |
+| services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-anthos                                                                  | client-name-projects |
+| services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-anthosconfigmanagement                                                  | client-name-projects |
+| services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-gkehub                                                                  | client-name-projects |
+| services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-gkeconnect                                                              | client-name-projects |
+| services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-kms                                                                     | client-name-projects |
+| services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-secretmanager                                                           | client-name-projects |
+| services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-artifactregistry                                                        | client-name-projects |
+| services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-containerscanning                                                       | client-name-projects |
+| services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-certificatemanager                                                      | client-name-projects |
+| services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-pubsub                                                                  | client-name-projects |
+
+## Resource References
+
+- [GKEHubFeature](https://cloud.google.com/config-connector/docs/reference/resource-docs/gkehub/gkehubfeature)
+- [IAMAuditConfig](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamauditconfig)
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [MonitoringAlertPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/monitoring/monitoringalertpolicy)
+- [MonitoringNotificationChannel](https://cloud.google.com/config-connector/docs/reference/resource-docs/monitoring/monitoringnotificationchannel)
+- [PubSubSubscription](https://cloud.google.com/config-connector/docs/reference/resource-docs/pubsub/pubsubsubscription)
+- [PubSubTopic](https://cloud.google.com/config-connector/docs/reference/resource-docs/pubsub/pubsubtopic)
+- [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/gke/configconnector/gke-setup@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd "./gke-setup/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/gke/configconnector/gke-setup/gkehub-feature-acm.yaml
+++ b/solutions/gke/configconnector/gke-setup/gkehub-feature-acm.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Anthos Config Management Feature
+apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
+kind: GKEHubFeature
+metadata:
+  name: project-id-acm-hubfeature # kpt-set: ${project-id}-acm-hubfeature
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+spec:
+  projectRef:
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  location: global
+  resourceID: configmanagement

--- a/solutions/gke/configconnector/gke-setup/host-project/project-iam.yaml
+++ b/solutions/gke/configconnector/gke-setup/host-project/project-iam.yaml
@@ -1,0 +1,107 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Service account names
+# GKE: service-SERVICE_PROJECT_1_NUM@container-engine-robot.iam.gserviceaccount.com
+# Google APIs: SERVICE_PROJECT_1_NUM@cloudservices.gserviceaccount.com
+# https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#determining_the_names_of_service_accounts_in_your_service_projects
+##################
+# Grant role: roles/compute.networkUser on the host project to SERVICE_PROJECT_1_NUM@cloudservices.gserviceaccount.com
+# https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#enabling_and_granting_roles
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-cloudservices-sa-networkuser-host-project-id-permissions # kpt-set: ${project-id}-cloudservices-sa-networkuser-${host-project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: host-project-id # kpt-set: ${host-project-id}
+  role: roles/compute.networkUser
+  member: "serviceAccount:project-number@cloudservices.gserviceaccount.com" # kpt-set: serviceAccount:${project-number}@cloudservices.gserviceaccount.com
+---
+# Grant role: roles/compute.networkUser on the host project to service-SERVICE_PROJECT_1_NUM@container-engine-robot.iam.gserviceaccount.com
+# https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#enabling_and_granting_roles
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-container-engine-robot-sa-networkuser-host-project-id-permissions # kpt-set: ${project-id}-container-engine-robot-sa-networkuser-${host-project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: host-project-id # kpt-set: ${host-project-id}
+  role: roles/compute.networkUser
+  member: "serviceAccount:service-project-number@container-engine-robot.iam.gserviceaccount.com" # kpt-set: serviceAccount:service-${project-number}@container-engine-robot.iam.gserviceaccount.com
+---
+# Grant custom role: gkefirewall.admin on the host project to service-SERVICE_PROJECT_1_NUM@container-engine-robot.iam.gserviceaccount.com
+# If you want a GKE cluster in a service project to create and manage the firewall resources in your host project,
+# the service project's GKE service account must be granted the appropriate IAM permissions
+# https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#managing_firewall_resources
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-container-engine-robot-sa-gkefirewall-admin-host-project-id-permissions # kpt-set: ${project-id}-container-engine-robot-sa-gkefirewall-admin-${host-project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: host-project-id # kpt-set: ${host-project-id}
+  role: organizations/org-id/roles/gkefirewall.admin # kpt-set: organizations/${org-id}/roles/gkefirewall.admin
+  member: "serviceAccount:service-project-number@container-engine-robot.iam.gserviceaccount.com" # kpt-set: serviceAccount:service-${project-number}@container-engine-robot.iam.gserviceaccount.com
+---
+# Grant custom role: Tier3 Subnetwork Admin on the host project to tier3 SA
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier3-sa-tier3-subnetwork-admin-host-project-id-permissions # kpt-set: ${project-id}-tier3-sa-tier3-subnetwork-admin-${host-project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: host-project-id # kpt-set: ${host-project-id}
+  role: organizations/org-id/roles/tier3.subnetwork.admin # kpt-set: organizations/${org-id}/roles/tier3.subnetwork.admin
+  member: "serviceAccount:tier3-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier3-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant role: Kubernetes Engine Host Service Agent User on the host project to service-SERVICE_PROJECT_1_NUM@container-engine-robot.iam.gserviceaccount.com
+# Each service project's GKE service account must have a binding for the Host Service Agent User role on the host project
+# https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#grant_host_service_agent_role
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-container-engine-robot-sa-host-servce-agent-host-project-id-permissions # kpt-set: ${project-id}-container-engine-robot-sa-host-servce-agent-${host-project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: host-project-id # kpt-set: ${host-project-id}
+  role: roles/container.hostServiceAgentUser
+  member: "serviceAccount:service-project-number@container-engine-robot.iam.gserviceaccount.com" # kpt-set: serviceAccount:service-${project-number}@container-engine-robot.iam.gserviceaccount.com

--- a/solutions/gke/configconnector/gke-setup/logging-monitoring/alerts.yaml
+++ b/solutions/gke/configconnector/gke-setup/logging-monitoring/alerts.yaml
@@ -45,7 +45,7 @@ spec:
   documentation:
     content: |-
       A critical severity alert, ${policy.display_name}, has been triggered for the ${resource.label.cluster_name} GKE cluster hosted inside the ${resource.project} project.
-
+      -
       The affected workload is ${log.extracted_label.namespace}. Please consult the GKE Security Posture Dashboard and Concerns page for more information.
   enabled: true
   notificationChannels:
@@ -82,7 +82,7 @@ spec:
   documentation:
     content: |-
       A high severity alert, ${policy.display_name}, has been triggered for the ${resource.label.cluster_name} GKE cluster hosted inside the ${resource.project} project.
-
+      -
       The affected workload is ${log.extracted_label.namespace}. Please consult the GKE Security Posture Dashboard and Concerns page for more information.
   enabled: true
   notificationChannels:
@@ -119,7 +119,7 @@ spec:
   documentation:
     content: |-
       A medium severity alert, ${policy.display_name}, has been triggered for the ${resource.label.cluster_name} GKE cluster hosted inside the ${resource.project} project.
-
+      -
       The affected workload is ${log.extracted_label.namespace}. Please consult the GKE Security Posture Dashboard and Concerns page for more information.
   enabled: true
   notificationChannels:
@@ -156,7 +156,7 @@ spec:
   documentation:
     content: |-
       A low severity alert, ${policy.display_name}, has been triggered for the ${resource.label.cluster_name} GKE cluster hosted inside the ${resource.project} project.
-
+      -
       The affected workload is ${log.extracted_label.namespace}. Please consult the GKE Security Posture Dashboard and Concerns page for more information.
   enabled: true
   notificationChannels:
@@ -200,7 +200,7 @@ spec:
   documentation:
     content: |-
       A message has been received by the gke-cluster-notification-pubsub-topic Cloud Pub/Sub topic.
-
+      -
       For more details, please visit the Cloud Pub/Sub Console, and pull messages from the gke-cluster-notification-pubsub-sub
       Cloud Pub/Sub Subscription.
   enabled: true
@@ -240,7 +240,7 @@ spec:
   documentation:
     content: |-
       A GKE cluster upgrade notification, ${policy.display_name}, has been triggered for the ${resource.label.cluster_name} GKE cluster hosted inside the ${resource.project} project.
-
+      -
       The GKE cluster has been upgraded from ${log.extracted_label.previousMasterVersion} to ${log.extracted_label.currentMasterVersion}. Please consult the GKE Kubernetes Console and logs for more details.
   enabled: true
   notificationChannels:

--- a/solutions/gke/configconnector/gke-setup/logging-monitoring/alerts.yaml
+++ b/solutions/gke/configconnector/gke-setup/logging-monitoring/alerts.yaml
@@ -1,0 +1,247 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# GKE Security Posture Dashboard Alert Policies
+# https://cloud.google.com/kubernetes-engine/docs/concepts/about-security-posture-dashboard
+# GKE Security Posture Critical Severity Alert Policy
+apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+kind: MonitoringAlertPolicy
+metadata:
+  name: project-id-gke-security-posture-critical-severity-alert # kpt-set: ${project-id}-gke-security-posture-critical-severity-alert
+  namespace: client-name-logging # kpt-set: ${client-name}-logging
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/${project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  alertStrategy:
+    # auto close after 7 days
+    autoClose: 604800s
+    notificationRateLimit:
+      # one notification per day
+      period: 86400s
+  combiner: OR
+  conditions:
+    - conditionMatchedLog:
+        filter: |-
+          LOG_ID("containersecurity.googleapis.com/finding")
+          jsonPayload.severity="SEVERITY_CRITICAL"
+        labelExtractors:
+          # This extracts the name of the affected resource
+          namespace: EXTRACT(jsonPayload.resourceName)
+      displayName: Log match condition
+      name: gke-security-posture-critical-severity-alert
+  displayName: GKE Security Posture Critical Severity
+  documentation:
+    content: |-
+      A critical severity alert, ${policy.display_name}, has been triggered for the ${resource.label.cluster_name} GKE cluster hosted inside the ${resource.project} project.
+
+      The affected workload is ${log.extracted_label.namespace}. Please consult the GKE Security Posture Dashboard and Concerns page for more information.
+  enabled: true
+  notificationChannels:
+    - name: project-id-gke-monitoring-group-notify # kpt-set: ${project-id}-gke-monitoring-group-notify
+---
+# GKE Security Posture High Severity Alert Policy
+apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+kind: MonitoringAlertPolicy
+metadata:
+  name: project-id-gke-security-posture-high-severity-alert # kpt-set: ${project-id}-gke-security-posture-high-severity-alert
+  namespace: client-name-logging # kpt-set: ${client-name}-logging
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/${project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  alertStrategy:
+    # auto close after 7 days
+    autoClose: 604800s
+    notificationRateLimit:
+      # one notification per day
+      period: 86400s
+  combiner: OR
+  conditions:
+    - conditionMatchedLog:
+        filter: |-
+          LOG_ID("containersecurity.googleapis.com/finding")
+          jsonPayload.severity="SEVERITY_HIGH"
+        labelExtractors:
+          # This extracts the name of the affected resource
+          namespace: EXTRACT(jsonPayload.resourceName)
+      displayName: Log match condition
+      name: gke-security-posture-high-severity-alert
+  displayName: GKE Security Posture High Severity
+  documentation:
+    content: |-
+      A high severity alert, ${policy.display_name}, has been triggered for the ${resource.label.cluster_name} GKE cluster hosted inside the ${resource.project} project.
+
+      The affected workload is ${log.extracted_label.namespace}. Please consult the GKE Security Posture Dashboard and Concerns page for more information.
+  enabled: true
+  notificationChannels:
+    - name: project-id-gke-monitoring-group-notify # kpt-set: ${project-id}-gke-monitoring-group-notify
+---
+# GKE Security Posture Medium Severity Alert Policy
+apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+kind: MonitoringAlertPolicy
+metadata:
+  name: project-id-gke-security-posture-medium-severity-alert # kpt-set: ${project-id}-gke-security-posture-medium-severity-alert
+  namespace: client-name-logging # kpt-set: ${client-name}-logging
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/${project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  alertStrategy:
+    # auto close after 7 days
+    autoClose: 604800s
+    notificationRateLimit:
+      # one notification per day
+      period: 86400s
+  combiner: OR
+  conditions:
+    - conditionMatchedLog:
+        filter: |-
+          LOG_ID("containersecurity.googleapis.com/finding")
+          jsonPayload.severity="SEVERITY_MEDIUM"
+        labelExtractors:
+          # This extracts the name of the affected resource
+          namespace: EXTRACT(jsonPayload.resourceName)
+      displayName: Log match condition
+      name: gke-security-posture-medium-severity-alert
+  displayName: GKE Security Posture Medium Severity
+  documentation:
+    content: |-
+      A medium severity alert, ${policy.display_name}, has been triggered for the ${resource.label.cluster_name} GKE cluster hosted inside the ${resource.project} project.
+
+      The affected workload is ${log.extracted_label.namespace}. Please consult the GKE Security Posture Dashboard and Concerns page for more information.
+  enabled: true
+  notificationChannels:
+    - name: project-id-gke-monitoring-group-notify # kpt-set: ${project-id}-gke-monitoring-group-notify
+---
+# GKE Security Posture Low Severity Alert Policy
+apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+kind: MonitoringAlertPolicy
+metadata:
+  name: project-id-gke-security-posture-low-severity-alert # kpt-set: ${project-id}-gke-security-posture-low-severity-alert
+  namespace: client-name-logging # kpt-set: ${client-name}-logging
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/${project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  alertStrategy:
+    # auto close after 7 days
+    autoClose: 604800s
+    notificationRateLimit:
+      # one notification per day
+      period: 86400s
+  combiner: OR
+  conditions:
+    - conditionMatchedLog:
+        filter: |-
+          LOG_ID("containersecurity.googleapis.com/finding")
+          jsonPayload.severity="SEVERITY_LOW"
+        labelExtractors:
+          # This extracts the name of the affected resource
+          namespace: EXTRACT(jsonPayload.resourceName)
+      displayName: Log match condition
+      name: gke-security-posture-low-severity-alert
+  displayName: GKE Security Posture Low Severity
+  documentation:
+    content: |-
+      A low severity alert, ${policy.display_name}, has been triggered for the ${resource.label.cluster_name} GKE cluster hosted inside the ${resource.project} project.
+
+      The affected workload is ${log.extracted_label.namespace}. Please consult the GKE Security Posture Dashboard and Concerns page for more information.
+  enabled: true
+  notificationChannels:
+    - name: project-id-gke-monitoring-group-notify # kpt-set: ${project-id}-gke-monitoring-group-notify
+---
+# GKE Cluster Event Notification Alert Policy
+# Cloud Pub/Sub Publish Requests (pubsub.googleapis.com/topic/send_request_count) Metric Alert Policy
+# This metric alert policy checks for published messages to the Pub/Sub Topic ID configured for GKE Cluster Notifications
+apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+kind: MonitoringAlertPolicy
+metadata:
+  name: project-id-gke-cluster-event-notification-alert # kpt-set: ${project-id}-gke-cluster-event-notification-alert
+  namespace: client-name-logging # kpt-set: ${client-name}-logging
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/${project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  alertStrategy:
+    # auto close after 7 days
+    autoClose: 604800s
+  combiner: OR
+  conditions:
+    - conditionThreshold:
+        aggregations:
+          - alignmentPeriod: 60s
+            crossSeriesReducer: REDUCE_COUNT
+            groupByFields:
+              - resource.label.project_id
+              - resource.label.topic_id
+            perSeriesAligner: ALIGN_COUNT
+        comparison: COMPARISON_GT
+        duration: 0s
+        filter: |-
+          resource.type = "pubsub_topic" AND resource.labels.topic_id = "gke-cluster-notification-pubsub-topic"
+          AND metric.type = "pubsub.googleapis.com/topic/send_request_count"
+        trigger:
+          count: 1
+      displayName: Publish Message Count
+      name: gke-cluster-event-notification-alert
+  displayName: GKE Cluster Event Detected
+  documentation:
+    content: |-
+      A message has been received by the gke-cluster-notification-pubsub-topic Cloud Pub/Sub topic.
+
+      For more details, please visit the Cloud Pub/Sub Console, and pull messages from the gke-cluster-notification-pubsub-sub
+      Cloud Pub/Sub Subscription.
+  enabled: true
+  notificationChannels:
+    - name: project-id-gke-monitoring-group-notify # kpt-set: ${project-id}-gke-monitoring-group-notify
+---
+# GKE Cluster Upgrade Notification
+apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+kind: MonitoringAlertPolicy
+metadata:
+  name: project-id-gke-cluster-upgrade-alert # kpt-set: ${project-id}-gke-cluster-upgrade-alert
+  namespace: client-name-logging # kpt-set: ${client-name}-logging
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/${project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  alertStrategy:
+    # auto after 7 days
+    autoClose: 604800s
+    notificationRateLimit:
+      # one notification per day
+      period: 86400s
+  combiner: OR
+  conditions:
+    - conditionMatchedLog:
+        filter: |-
+          resource.type="gke_cluster"
+          proto_payload.method_name="google.container.v1.ClusterManager.UpdateCluster"
+          protoPayload.metadata.operationType="UPGRADE_MASTER"
+        labelExtractors:
+          # This extracts the version numbers of the previous and current Master GKE Versions
+          previousMasterVersion: EXTRACT(protoPayload.metadata.previousMasterVersion)
+          currentMasterVersion: EXTRACT(protoPayload.metadata.currentMasterVersion)
+      displayName: Log match condition
+      name: gke-cluster-upgrade-alert
+  displayName: GKE Cluster Upgrade Notification
+  documentation:
+    content: |-
+      A GKE cluster upgrade notification, ${policy.display_name}, has been triggered for the ${resource.label.cluster_name} GKE cluster hosted inside the ${resource.project} project.
+
+      The GKE cluster has been upgraded from ${log.extracted_label.previousMasterVersion} to ${log.extracted_label.currentMasterVersion}. Please consult the GKE Kubernetes Console and logs for more details.
+  enabled: true
+  notificationChannels:
+    - name: project-id-gke-monitoring-group-notify # kpt-set: ${project-id}-gke-monitoring-group-notify

--- a/solutions/gke/configconnector/gke-setup/logging-monitoring/notificationchannel.yaml
+++ b/solutions/gke/configconnector/gke-setup/logging-monitoring/notificationchannel.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Notification channel for GKE cluster logs
+apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+kind: MonitoringNotificationChannel
+metadata:
+  name: project-id-gke-monitoring-group-notify # kpt-set: ${project-id}-gke-monitoring-group-notify
+  namespace: client-name-logging # kpt-set: ${client-name}-logging
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  type: email
+  labels:
+    email_address: group@example.com # kpt-set: ${gke-monitoring-group}
+  description: A notification channel to send GKE cluster alerts using email

--- a/solutions/gke/configconnector/gke-setup/logging-monitoring/pubsub.yaml
+++ b/solutions/gke/configconnector/gke-setup/logging-monitoring/pubsub.yaml
@@ -1,0 +1,51 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# PubSub Topic for GKE Cluster Notifications
+apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
+kind: PubSubTopic
+metadata:
+  name: project-id-gke-cluster-notification-pubsub-topic # kpt-set: ${project-id}-gke-cluster-notification-pubsub-topic
+  namespace: client-name-logging # kpt-set: ${client-name}-logging
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client1-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  # Messages are retained for 7 days
+  messageRetentionDuration: 604800s
+  messageStoragePolicy:
+    allowedPersistenceRegions:
+      - northamerica-northeast1
+      - northamerica-northeast2
+  resourceID: gke-cluster-notification-pubsub-topic
+---
+# PubSub Subscription for GKE Cluster Notifications
+apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
+kind: PubSubSubscription
+metadata:
+  name: project-id-gke-cluster-notification-pubsub-subscription # kpt-set: ${project-id}-gke-cluster-notification-pubsub-subscription
+  namespace: client-name-logging # kpt-set: ${client-name}-logging
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client1-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  ackDeadlineSeconds: 300
+  # Messages are retained for 7 days
+  messageRetentionDuration: 604800s
+  resourceID: gke-cluster-notification-pubsub-sub
+  # Retain acknowledged messages
+  retainAckedMessages: true
+  topicRef:
+    name: project-id-gke-cluster-notification-pubsub-topic # kpt-set: ${project-id}-gke-cluster-notification-pubsub-topic
+    namespace: client-name-logging # kpt-set: ${client-name}-logging

--- a/solutions/gke/configconnector/gke-setup/project-iam.yaml
+++ b/solutions/gke/configconnector/gke-setup/project-iam.yaml
@@ -1,0 +1,168 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Grant GCP role GKE Hub admin to Tier3 SA on Service Project
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# IAM permissions required to register cluster to anthos fleet and workload identity
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier3-sa-gke-hub-admin-project-id-permissions # kpt-set: ${project-id}-tier3-sa-gke-hub-admin-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: roles/gkehub.admin
+  member: "serviceAccount:tier3-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier3-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant GCP role Container admin to Tier3 SA on Service Project
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# IAM permissions required to register cluster to anthos fleet (also gives full access to cluster)
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier3-sa-container-admin-project-id-permissions # kpt-set: ${project-id}-tier3-sa-container-admin-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: roles/container.admin
+  member: "serviceAccount:tier3-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier3-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant GCP role Compute Engine Service Agent to Tier3 SA on Service Project
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# IAM permissions required to create k8s cluster
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier3-sa-service-agent-project-id-permissions # kpt-set: ${project-id}-tier3-sa-service-agent-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: roles/compute.serviceAgent
+  member: "serviceAccount:tier3-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier3-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant GCP role KMS admin to Tier3 SA on Service Project
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier3-sa-kms-admin-project-id-permissions # kpt-set: ${project-id}-tier3-sa-kms-admin-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: roles/cloudkms.admin
+  member: "serviceAccount:tier3-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier3-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant role Cloud KMS CryptoKey Encrypter/Decrypter on the Service Project to service-SERVICE_PROJECT_1_NUM@container-engine-robot.iam.gserviceaccount.com
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-container-engine-robot-sa-kms-encrypt-decrypt-project-id-permissions # kpt-set: ${project-id}-container-engine-robot-sa-kms-encrypt-decrypt-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: roles/cloudkms.cryptoKeyEncrypterDecrypter
+  member: "serviceAccount:service-project-number@container-engine-robot.iam.gserviceaccount.com" # kpt-set: serviceAccount:service-${project-number}@container-engine-robot.iam.gserviceaccount.com
+---
+# Grant role Artifact Registry Administrator to Tier4 SA on Service Project
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier4-sa-artifactregistry-admin-project-id-permissions # kpt-set: ${project-id}-tier4-sa-artifactregistry-admin-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: roles/artifactregistry.admin
+  member: "serviceAccount:tier4-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier4-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant role Tier4 Secret Manager Admin to Tier4 SA on Service Project
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier4-sa-tier4-secret-manager-admin-project-id-permissions # kpt-set: ${project-id}-tier4-sa-tier4-secret-manager-admin-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: organizations/org-id/roles/tier4.secretmanager.admin # kpt-set: organizations/${org-id}/roles/tier4.secretmanager.admin
+  member: "serviceAccount:tier4-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier4-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant role Pub Sub Admin to client-name-logging SA on Service Project
+# Required for GKE notification that uses pub-sub
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: client-name-logging-sa-pubsub-admin-project-id-permissions # kpt-set: ${client-name}-logging-sa-pubsub-admin-${project-id}-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+  role: roles/pubsub.admin
+  member: "serviceAccount:client-name-logging-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-logging-sa@${client-management-project-id}.iam.gserviceaccount.com
+---
+# Enable the Kubernetes Engine API data access log configuration on the GKE service project
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMAuditConfig
+metadata:
+  name: project-id-data-access-log-config # kpt-set: ${project-id}-data-access-log-config
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client1-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  service: container.googleapis.com
+  auditLogConfigs:
+    - logType: ADMIN_READ
+    - logType: DATA_READ
+    - logType: DATA_WRITE
+  resourceRef:
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects

--- a/solutions/gke/configconnector/gke-setup/securitycontrols.md
+++ b/solutions/gke/configconnector/gke-setup/securitycontrols.md
@@ -1,0 +1,13 @@
+# Security Controls
+
+<!-- BEGINNING OF SECURITY CONTROLS LIST -->
+|Security Control|File Name|Resource Name|
+|---|---|---|
+|AC-3(7)|./host-project/project-iam.yaml|project-id-cloudservices-sa-networkuser-host-project-id-permissions|
+|AC-3(7)|./host-project/project-iam.yaml|project-id-container-engine-robot-sa-networkuser-host-project-id-permissions|
+|AC-3(7)|./project-iam.yaml|project-id-tier3-sa-container-admin-project-id-permissions|
+|AC-3(7)|./project-iam.yaml|project-id-tier3-sa-gke-hub-admin-project-id-permissions|
+|AC-3(7)|./project-iam.yaml|project-id-tier3-sa-kms-admin-project-id-permissions|
+|AC-3(7)|./project-iam.yaml|project-id-tier3-sa-service-agent-project-id-permissions|
+
+<!-- END OF SECURITY CONTROLS LIST -->

--- a/solutions/gke/configconnector/gke-setup/services.yaml
+++ b/solutions/gke/configconnector/gke-setup/services.yaml
@@ -1,4 +1,3 @@
-
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/solutions/gke/configconnector/gke-setup/services.yaml
+++ b/solutions/gke/configconnector/gke-setup/services.yaml
@@ -1,0 +1,164 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Cloud Resource Manager API and IAM api are defined in the client-project-setup package
+######
+# Container API
+# Required for Allowing GKE clusters to be deployed in service projects
+# Enabling the API in a project creates a GKE service account for the project.
+# https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-container # kpt-set: ${project-id}-container
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: container.googleapis.com
+---
+# Container Security API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-containersecurity # kpt-set: ${project-id}-containersecurity
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: containersecurity.googleapis.com
+---
+# Anthos API
+# https://cloud.google.com/anthos/fleet-management/docs/before-you-begin
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-anthos # kpt-set: ${project-id}-anthos
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: anthos.googleapis.com
+---
+# Anthos Config Management API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-anthosconfigmanagement # kpt-set: ${project-id}-anthosconfigmanagement
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: anthosconfigmanagement.googleapis.com
+---
+# GKE Hub API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-gkehub # kpt-set: ${project-id}-gkehub
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: gkehub.googleapis.com
+---
+# GKE Connect API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-gkeconnect # kpt-set: ${project-id}-gkeconnect
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: gkeconnect.googleapis.com
+---
+# Key Management Service API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-kms # kpt-set: ${project-id}-kms
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: cloudkms.googleapis.com
+---
+# Secret Manager API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-secretmanager # kpt-set: ${project-id}-secretmanager
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: secretmanager.googleapis.com
+---
+# Artifact Registry API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-artifactregistry # kpt-set: ${project-id}-artifactregistry
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: artifactregistry.googleapis.com
+---
+# Container Scanning API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-containerscanning # kpt-set: ${project-id}-containerscanning
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: containerscanning.googleapis.com
+---
+# Certificate Manager API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-certificatemanager # kpt-set: ${project-id}-certificatemanager
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: certificatemanager.googleapis.com
+---
+# Pub/Sub API
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: project-id-pubsub # kpt-set: ${project-id}-pubsub
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  resourceID: pubsub.googleapis.com

--- a/solutions/gke/configconnector/gke-setup/setters.yaml
+++ b/solutions/gke/configconnector/gke-setup/setters.yaml
@@ -1,0 +1,63 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  #
+  ##########################
+  # General Settings Values
+  ##########################
+  #
+  org-id: "0000000000"
+  # The group email address to use for the GKE cluster alerts
+  gke-monitoring-group: "group@example.com"
+  #
+  ##########################
+  # Client
+  ##########################
+  #
+  # Name for the client, lowercase only
+  client-name: 'client1'
+  # project id for the client management project, following rules and conventions
+  client-management-project-id: client-management-project-12345
+  #
+  ##########################
+  # Network Host Project
+  ##########################
+  #
+  # the network host project id
+  host-project-id: net-host-project-12345
+  #
+  ##########################
+  # Project
+  ##########################
+  #
+  # the project id that was created by the client-project-setup
+  project-id: project-12345
+  # the project number that was created by the client-project-setup
+  project-number: "0000000000"
+  #
+  ##########################
+  # End of Configurations
+  ##########################


### PR DESCRIPTION
Landing zone v2 subpackage.
Depends on package `client-project-setup`.
Deploy this package once per service project.

Package to prepare a service project for GKE clusters. 
- several APIs are enabled
- enables anthos config management
- defines a monitoring foundation
- grant permissions on the host project to api service accounts

provides a portion of the solution to #479 