### PR TITLE
feat: gke-defaults package

### DIFF
--- a/solutions/gke/configconnector/gke-defaults/Kptfile
+++ b/solutions/gke/configconnector/gke-defaults/Kptfile
@@ -1,0 +1,19 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: gke-defaults
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    Landing zone v2 subpackage.
+    Depends on package `gke-setup`.
+    Requires project-id-tier3 namespace.
+
+    Deploy this package once per service project.
+
+    A package to deploy common GKE resources. It include roles granted to a user or group for vizualizing GKE.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/gke/configconnector/gke-defaults/Kptfile
+++ b/solutions/gke/configconnector/gke-defaults/Kptfile
@@ -13,6 +13,11 @@ info:
     Deploy this package once per service project.
 
     A package to deploy common GKE resources. It include roles granted to a user or group for vizualizing GKE.
+
+    Warning! It requires the alpha CRD [computmanagedsslcertificate](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/crds/compute_v1alpha1_computemanagedsslcertificate.yaml)
+    loaded in the config controller.
+
+    [Install alpha CRDS](https://cloud.google.com/config-connector/docs/how-to/install-alpha-crds)
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/apply-setters:v0.2

--- a/solutions/gke/configconnector/gke-defaults/README.md
+++ b/solutions/gke/configconnector/gke-defaults/README.md
@@ -1,0 +1,89 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# gke-defaults
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+Landing zone v2 subpackage.
+Depends on package `gke-setup`.
+Requires project-id-tier3 namespace.
+
+Deploy this package once per service project.
+
+A package to deploy common GKE resources. It include roles granted to a user or group for vizualizing GKE.
+
+## Setters
+
+|       Name       |           Value           | Type  | Count |
+|------------------|---------------------------|-------|-------|
+| certificate-id   |                  12345678 | int   |     1 |
+| certificate-name | certificate-name          | str   |     3 |
+| client-name      | client1                   | str   |     6 |
+| domains          | [example.com]             | array |     1 |
+| gateway-name     | gateway-name              | str   |     2 |
+| host-project-id  | host-project-12345        | str   |     0 |
+| project-id       | project-12345             | str   |    10 |
+| team-gkeviewer   | group:client1@example.com | str   |     6 |
+
+## Sub-packages
+
+- [dns](gateway-setup/dns)
+- [gateway-setup](gateway-setup)
+- [ssl-certificate](gateway-setup/ssl-certificate)
+
+## Resources
+
+|       File       |            APIVersion             |      Kind       |                 Name                  | Namespace |
+|------------------|-----------------------------------|-----------------|---------------------------------------|-----------|
+| project-iam.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | containerclusterviewer-permissions    |           |
+| project-iam.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | loggingviewer-permissions             |           |
+| project-iam.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | monitoringviewer-permissions          |           |
+| project-iam.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | monitoringdashboardeditor-permissions |           |
+| project-iam.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | pubsubviewer-permissions              |           |
+| project-iam.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | pubsubsubscriber-permissions          |           |
+
+## Resource References
+
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/gke/configconnector/gke-defaults@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd "./gke-defaults/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/gke/configconnector/gke-defaults/README.md
+++ b/solutions/gke/configconnector/gke-defaults/README.md
@@ -13,6 +13,11 @@ Deploy this package once per service project.
 
 A package to deploy common GKE resources. It include roles granted to a user or group for vizualizing GKE.
 
+Warning! It requires the alpha CRD [computmanagedsslcertificate](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/crds/compute_v1alpha1_computemanagedsslcertificate.yaml)
+loaded in the config controller.
+
+[Install alpha CRDS](https://cloud.google.com/config-connector/docs/how-to/install-alpha-crds)
+
 ## Setters
 
 |       Name       |           Value           | Type  | Count |

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/Kptfile
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/Kptfile
@@ -1,0 +1,18 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: gateway-setup
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    gke subpackage.
+    Requires project-id-tier3 namespace.
+
+    Deploy this package once per gateway resources. You can have multiple copies of this subpackage by cloning the entire folder to a new folder (i.e. subpackage2)
+
+    This package deploys the resources that are required by a kubernetes gateway (Gateway Controller).
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/README.md
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/README.md
@@ -1,0 +1,83 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# gateway-setup
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+gke subpackage.
+Requires project-id-tier3 namespace.
+
+Deploy this package once per gateway resources. You can have multiple copies of this subpackage by cloning the entire folder to a new folder (i.e. subpackage2)
+
+This package deploys the resources that are required by a kubernetes gateway (Gateway Controller).
+
+## Setters
+
+|       Name       |      Value       | Type  | Count |
+|------------------|------------------|-------|-------|
+| certificate-id   |         12345678 | int   |     1 |
+| certificate-name | certificate-name | str   |     3 |
+| client-name      | client-name      | str   |     2 |
+| dns-project-id   | dns-project-id   | str   |     1 |
+| domains          | [example.com]    | array |     1 |
+| gateway-name     | sample-gateway   | str   |     3 |
+| metadata-name    | metadata-name    | str   |     1 |
+| project-id       | project-12345    | str   |     6 |
+| spec-name        | dns-name         | str   |     1 |
+
+## Sub-packages
+
+- [dns](dns)
+- [ssl-certificate](ssl-certificate)
+
+## Resources
+
+|  File   |              APIVersion               |      Kind      |             Name             |    Namespace     |
+|---------|---------------------------------------|----------------|------------------------------|------------------|
+| ip.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeAddress | gateway-name-compute-address | project-id-tier3 |
+
+## Resource References
+
+- [ComputeAddress](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeaddress)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/gke/configconnector/gke-defaults/gateway-setup@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd "./gateway-setup/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/Kptfile
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/Kptfile
@@ -1,0 +1,18 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: dns
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    gateway-setup subpackage.
+    Requires project-id-tier3 namespace.
+
+    Deploy this package once per dns record resources. You can have multiple copies of this subpackage by cloning the entire folder to a new folder (i.e. subpackage2)
+
+    This package deploys a dns a record that is required by a kubernetes gateway (Gateway Controller).
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/README.md
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/README.md
@@ -1,0 +1,79 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# dns
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+gateway-setup subpackage.
+Requires project-id-tier3 namespace.
+
+Deploy this package once per dns record resources. You can have multiple copies of this subpackage by cloning the entire folder to a new folder (i.e. subpackage2)
+
+This package deploys a dns a record that is required by a kubernetes gateway (Gateway Controller).
+
+## Setters
+
+|      Name      |          Value           | Type | Count |
+|----------------|--------------------------|------|-------|
+| client-name    | client1                  | str  |     2 |
+| dns-project-id | dns-project-12345        | str  |     1 |
+| gateway-name   | sample-gateway           | str  |     1 |
+| metadata-name  | sample-name-recordset    | str  |     1 |
+| project-id     | project-12345            | str  |     2 |
+| spec-name      | sample-name.example.com. | str  |     1 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|   File   |            APIVersion             |     Kind     |     Name      |    Namespace     |
+|----------|-----------------------------------|--------------|---------------|------------------|
+| dns.yaml | dns.cnrm.cloud.google.com/v1beta1 | DNSRecordSet | metadata-name | project-id-tier3 |
+
+## Resource References
+
+- [DNSRecordSet](https://cloud.google.com/config-connector/docs/reference/resource-docs/dns/dnsrecordset)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/gke/configconnector/gke-defaults/gateway-setup/dns@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd "./dns/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/dns.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/dns.yaml
@@ -1,0 +1,35 @@
+# # Copyright 2020 Google LLC
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+# #########
+# # create a DNS A record referencing the gateway address
+# # SC-22
+# apiVersion: dns.cnrm.cloud.google.com/v1beta1
+# kind: DNSRecordSet
+# metadata:
+#   name: metadata-name # kpt-set: ${metadata-name}
+#   namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+#   annotations:
+#     cnrm.cloud.google.com/project-id: dns-project-id # kpt-set: ${dns-project-id}
+# spec:
+#   name: "dns-name" # kpt-set: ${spec-name}
+#   type: "A"
+#   ttl: 300
+#   managedZoneRef:
+#     name: client-name-standard-public-dns # kpt-set: ${client-name}-standard-public-dns
+#     namespace: client-name-networking # kpt-set: ${client-name}-networking
+#   rrdatasRefs:
+#     - name: gateway-name-compute-address # kpt-set: ${gateway-name}-compute-address
+#       namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+#       kind: ComputeAddress
+

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/dns.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/dns.yaml
@@ -1,35 +1,34 @@
-# # Copyright 2020 Google LLC
-# #
-# # Licensed under the Apache License, Version 2.0 (the "License");
-# # you may not use this file except in compliance with the License.
-# # You may obtain a copy of the License at
-# #
-# #     http://www.apache.org/licenses/LICENSE-2.0
-# #
-# # Unless required by applicable law or agreed to in writing, software
-# # distributed under the License is distributed on an "AS IS" BASIS,
-# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# # See the License for the specific language governing permissions and
-# # limitations under the License.
-# #########
-# # create a DNS A record referencing the gateway address
-# # SC-22
-# apiVersion: dns.cnrm.cloud.google.com/v1beta1
-# kind: DNSRecordSet
-# metadata:
-#   name: metadata-name # kpt-set: ${metadata-name}
-#   namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
-#   annotations:
-#     cnrm.cloud.google.com/project-id: dns-project-id # kpt-set: ${dns-project-id}
-# spec:
-#   name: "dns-name" # kpt-set: ${spec-name}
-#   type: "A"
-#   ttl: 300
-#   managedZoneRef:
-#     name: client-name-standard-public-dns # kpt-set: ${client-name}-standard-public-dns
-#     namespace: client-name-networking # kpt-set: ${client-name}-networking
-#   rrdatasRefs:
-#     - name: gateway-name-compute-address # kpt-set: ${gateway-name}-compute-address
-#       namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
-#       kind: ComputeAddress
-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# create a DNS A record referencing the gateway address
+# SC-22
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: metadata-name # kpt-set: ${metadata-name}
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/project-id: dns-project-id # kpt-set: ${dns-project-id}
+spec:
+  name: "dns-name" # kpt-set: ${spec-name}
+  type: "A"
+  ttl: 300
+  managedZoneRef:
+    name: client-name-standard-public-dns # kpt-set: ${client-name}-standard-public-dns
+    namespace: client-name-networking # kpt-set: ${client-name}-networking
+  rrdatasRefs:
+    - name: gateway-name-compute-address # kpt-set: ${gateway-name}-compute-address
+      namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+      kind: ComputeAddress

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/setters.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/setters.yaml
@@ -1,0 +1,57 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  #
+  ##########################
+  # Client
+  ##########################
+  #
+  # Project that has the public dns zone. Usually the client host project that was created by the client-landing-zone package
+  dns-project-id: dns-project-12345
+  #
+  ##########################
+  # Gateway
+  ##########################
+  #
+  # The DNSRecordset.metadata.name (a.k.a kubernetes resource name)
+  metadata-name: sample-name-recordset
+  # The DNSRecordset.spec.name
+  spec-name: "sample-name.example.com."
+  # The Gateway name
+  gateway-name: sample-gateway
+  #
+  ##########################
+  # setters.yaml from parent package will override the value below
+  ##########################
+  #
+  # Name for the client, lowercase only
+  client-name: client1
+  # The project id that was created by the client-project-setup
+  project-id: project-12345
+  #
+  ##########################
+  # End of Configurations
+  ##########################

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/ip.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/ip.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Reserve an external IP address for a global load balancer. It will then be used by a kubernetes gateway.
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
+metadata:
+  name: gateway-name-compute-address # kpt-set: ${gateway-name}-compute-address
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  addressType: EXTERNAL
+  description: external IP for gateway-name # kpt-set: external IP for ${gateway-name}
+  ipVersion: IPV4
+  location: global

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/setters.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/setters.yaml
@@ -1,0 +1,44 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  #
+  ##########################
+  # Gateway
+  ##########################
+  #
+  # The name of the gateway resource
+  gateway-name: sample-gateway
+  #
+  ##########################
+  # setters.yaml from parent package will override the value below
+  ##########################
+  #
+  # The project id that was created by the client-project-setup
+  project-id: project-12345
+  #
+  ##########################
+  # End of Configurations
+  ##########################

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate/Kptfile
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate/Kptfile
@@ -1,0 +1,18 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: ssl-certificate
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    gateway-setup subpackage.
+    Requires project-id-tier3 namespace.
+
+    Deploy this package once per certificate. You can have multiple copies of this subpackage by cloning the entire folder to a new folder (i.e. subpackage2)
+
+    A package to deploy a google managed classic certificate.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate/README.md
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate/README.md
@@ -1,0 +1,77 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# ssl-certificate
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+gateway-setup subpackage.
+Requires project-id-tier3 namespace.
+
+Deploy this package once per certificate. You can have multiple copies of this subpackage by cloning the entire folder to a new folder (i.e. subpackage2)
+
+A package to deploy a google managed classic certificate.
+
+## Setters
+
+|       Name       |           Value           | Type  | Count |
+|------------------|---------------------------|-------|-------|
+| certificate-id   |                  12345678 | int   |     1 |
+| certificate-name | sample-name               | str   |     3 |
+| domains          | [sample-name.example.com] | array |     1 |
+| project-id       | project-12345             | str   |     2 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|   File   |               APIVersion               |             Kind             |                  Name                   |    Namespace     |
+|----------|----------------------------------------|------------------------------|-----------------------------------------|------------------|
+| ssl.yaml | compute.cnrm.cloud.google.com/v1alpha1 | ComputeManagedSSLCertificate | certificate-name-compute-sslcertificate | project-id-tier3 |
+
+## Resource References
+
+- [ComputeManagedSSLCertificate](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computemanagedsslcertificate)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd "./ssl-certificate/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate/setters.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate/setters.yaml
@@ -1,0 +1,49 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  #
+  ##########################
+  # Certificate
+  ##########################
+  #
+  # the unique identifier for the resource
+  certificate-id: 12345678
+  # a resource name for this certificate
+  certificate-name: sample-name
+  # domains for which a managed SSL certificate will be valid. There can be up to 100 domains in this list.
+  domains: |
+    - sample-name.example.com
+  #
+  ##########################
+  # setters.yaml from parent package will override the value below
+  ##########################
+  #
+  # The project id that was created by the client-project-setup
+  project-id: project-12345
+  #
+  ##########################
+  # End of Configurations
+  ##########################

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate/ssl.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate/ssl.yaml
@@ -1,0 +1,35 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Google Managed Classic SSL certificate
+# Warning! requires the alpha resource loaded in the config controller
+# https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/crds/compute_v1alpha1_computemanagedsslcertificate.yaml
+# TODO: fix error message : Update call failed: error applying desired state: summary: doesn't support update
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeManagedSSLCertificate
+metadata:
+  name: certificate-name-compute-sslcertificate # kpt-set: ${certificate-name}-compute-sslcertificate
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: absent
+spec:
+  certificateId: 12345678 # kpt-set: ${certificate-id}
+  description: certificate-name Managed SSL Certificate # kpt-set: ${certificate-name} Managed SSL Certificate
+  managed:
+    domains: # kpt-set: ${domains}
+      - example.com
+  projectRef:
+    external: project-id # kpt-set: ${project-id}
+  resourceID: certificate-name # kpt-set: ${certificate-name}
+  type: MANAGED

--- a/solutions/gke/configconnector/gke-defaults/project-iam.yaml
+++ b/solutions/gke/configconnector/gke-defaults/project-iam.yaml
@@ -1,0 +1,117 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Client viewer permissions for GKE, logging, and monitoring
+#########
+# Grant role: roles/container.clusterViewer on the GKE Cluster project to client group
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: containerclusterviewer-permissions
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/container.clusterViewer
+  member: team-gkeviewer # kpt-set: ${team-gkeviewer}
+---
+# Grant role: roles/logging.viewer on the GKE Cluster project to client group
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: loggingviewer-permissions
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/logging.viewer
+  member: team-gkeviewer # kpt-set: ${team-gkeviewer}
+---
+# Grant role: roles/monitoring.viewer on the GKE Cluster project to client group
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: monitoringviewer-permissions
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/monitoring.viewer
+  member: team-gkeviewer # kpt-set: ${team-gkeviewer}
+---
+# Grant role: roles/monitoring.dashboardEditor on the GKE Cluster project to client group
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: monitoringdashboardeditor-permissions
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/monitoring.dashboardEditor
+  member: team-gkeviewer # kpt-set: ${team-gkeviewer}
+---
+# Grant role: roles/pubsub.viewer on the GKE Cluster project to client group
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: pubsubviewer-permissions
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/pubsub.viewer
+  member: team-gkeviewer # kpt-set: ${team-gkeviewer}
+---
+# Grant role: roles/pubsub.subscriber on the GKE Cluster project to client group
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: pubsubsubscriber-permissions
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/pubsub.subscriber
+  member: team-gkeviewer # kpt-set: ${team-gkeviewer}

--- a/solutions/gke/configconnector/gke-defaults/securitycontrols.md
+++ b/solutions/gke/configconnector/gke-defaults/securitycontrols.md
@@ -1,0 +1,6 @@
+# Security Controls
+
+<!-- BEGINNING OF SECURITY CONTROLS LIST -->
+
+
+<!-- END OF SECURITY CONTROLS LIST -->

--- a/solutions/gke/configconnector/gke-defaults/setters.yaml
+++ b/solutions/gke/configconnector/gke-defaults/setters.yaml
@@ -1,0 +1,48 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  #
+  ##########################
+  # Client
+  ##########################
+  #
+  # Name for the client, lowercase only
+  client-name: 'client1'
+  # group to grant gke, logging, and monitoring viewer permissions
+  team-gkeviewer: 'group:client1@example.com'
+  # the host project for this client
+  host-project-id: host-project-12345
+  #
+  ##########################
+  # Project
+  ##########################
+  #
+  # the project id that was created by the client-project-setup
+  project-id: project-12345
+  #
+  ##########################
+  # End of Configurations
+  ##########################


### PR DESCRIPTION
Landing zone v2 subpackage.
Depends on package `gke-setup`.
Requires project-id-tier3 namespace.

Deploy this package once per service project.

A package to deploy common GKE resources. 
- include roles granted to a user or group for visualizing GKE.
- ip reservation for an external global load balancers
- ssl certificate (requires the alpha CRD for now)
- dns record

This package is part of the solution for #479 