### PR TITLE
feat: gke-cluster-autopilot package

### DIFF
--- a/solutions/gke/configconnector/gke-cluster-autopilot/Kptfile
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/Kptfile
@@ -1,0 +1,19 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: gke-cluster-autopilot
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    Landing zone v2 subpackage.
+    Depends on package `gke-setup`.
+    Requires project-id-tier3 namespace.
+
+    Deploy this package once per GKE cluster.
+
+    A GKE Autopilot Cluster running in a service project. This package also deploys a dedicated subnet inside the host project.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/gke/configconnector/gke-cluster-autopilot/README.md
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/README.md
@@ -1,0 +1,121 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# gke-cluster-autopilot
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+Landing zone v2 subpackage.
+Depends on package `gke-setup`.
+Requires project-id-tier3 namespace.
+
+Deploy this package once per GKE cluster.
+
+A GKE Autopilot Cluster running in a service project. This package also deploys a dedicated subnet inside the host project.
+
+## Setters
+
+|              Name               |                     Value                      | Type  | Count |
+|---------------------------------|------------------------------------------------|-------|-------|
+| client-name                     | client1                                        | str   |    18 |
+| cluster-name                    | autopilot1-gke                                 | str   |    36 |
+| gke-to-azdo-priority            |                                           2000 | int   |     1 |
+| gke-to-docker-priority          |                                           2002 | int   |     1 |
+| gke-to-github-priority          |                                           2001 | int   |     1 |
+| host-project-id                 | host-project-12345                             | str   |     6 |
+| host-project-vpc                | host-project-vpc                               | str   |     2 |
+| location                        | northamerica-northeast1                        | str   |     5 |
+| master-authorized-networks-cidr | [cidrBlock: 10.1.1.5/32displayName: bastion]   | array |     1 |
+| masterIpv4CidrBlock             | 172.16.0.0/28                                  | str   |     1 |
+| masterIpv4Range                 | ["172.16.0.0/28"]                              | array |     0 |
+| podIpv4Range                    | ["240.1.0.0/21"]                               | array |     1 |
+| primaryIpv4Range                | ["10.1.32.0/24"]                               | array |     3 |
+| project-id                      | project-12345                                  | str   |    51 |
+| repo-branch                     | main                                           | str   |     1 |
+| repo-dir                        | csync/tier3/kubernetes/<fleet-id>/deploy/<env> | str   |     1 |
+| repo-url                        | tier34-repo-to-observe                         | str   |     1 |
+| subnet-pod-cidr                 | 240.1.0.0/21                                   | str   |     1 |
+| subnet-primary-cidr             | 10.1.32.0/24                                   | str   |     1 |
+| subnet-services-cidr            | 10.1.33.0/24                                   | str   |     1 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|                      File                       |               APIVersion                |           Kind            |                                Name                                 |    Namespace     |
+|-------------------------------------------------|-----------------------------------------|---------------------------|---------------------------------------------------------------------|------------------|
+| application-infrastructure-folder/firewall.yaml | compute.cnrm.cloud.google.com/v1beta1   | ComputeFirewallPolicyRule | project-id-cluster-name-egress-allow-azdo                           | project-id-tier3 |
+| application-infrastructure-folder/firewall.yaml | compute.cnrm.cloud.google.com/v1beta1   | ComputeFirewallPolicyRule | project-id-cluster-name-egress-allow-github                         | project-id-tier3 |
+| application-infrastructure-folder/firewall.yaml | compute.cnrm.cloud.google.com/v1beta1   | ComputeFirewallPolicyRule | project-id-cluster-name-egress-allow-docker                         | project-id-tier3 |
+| gke.yaml                                        | container.cnrm.cloud.google.com/v1beta1 | ContainerCluster          | autopilot1-gke                                                      | project-id-tier3 |
+| gkehub-featuremembership-acm.yaml               | gkehub.cnrm.cloud.google.com/v1beta1    | GKEHubFeatureMembership   | cluster-name-acm-hubfeaturemembership                               | project-id-tier3 |
+| gkehub-membership.yaml                          | gkehub.cnrm.cloud.google.com/v1beta1    | GKEHubMembership          | cluster-name                                                        | project-id-tier3 |
+| host-project/firewall.yaml                      | compute.cnrm.cloud.google.com/v1beta1   | ComputeFirewall           | project-id-cluster-name-lb-health-check                             |                  |
+| host-project/subnet.yaml                        | compute.cnrm.cloud.google.com/v1beta1   | ComputeSubnetwork         | project-id-cluster-name-snet                                        |                  |
+| kms.yaml                                        | kms.cnrm.cloud.google.com/v1beta1       | KMSKeyRing                | cluster-name-kmskeyring                                             | project-id-tier3 |
+| kms.yaml                                        | kms.cnrm.cloud.google.com/v1beta1       | KMSCryptoKey              | cluster-name-etcd-key                                               | project-id-tier3 |
+| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMServiceAccount         | cluster-name-sa                                                     | project-id-tier3 |
+| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-logwriter-permissions                               | project-id-tier3 |
+| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-metricwriter-permissions                            | project-id-tier3 |
+| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-monitoring-viewer-permissions                       | project-id-tier3 |
+| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-storage-object-viewer-permissions                   | project-id-tier3 |
+| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-stackdriver-metadata-writer-permissions             | project-id-tier3 |
+| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-artifactregistry-reader-permissions                 | project-id-tier3 |
+| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-secretmanager-secretaccessor-permissions            | project-id-tier3 |
+| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | project-id-tier3-sa-serviceaccount-user-cluster-name-sa-permissions | project-id-tier3 |
+
+## Resource References
+
+- [ComputeFirewallPolicyRule](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computefirewallpolicyrule)
+- [ComputeFirewall](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computefirewall)
+- [ComputeSubnetwork](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computesubnetwork)
+- [ContainerCluster](https://cloud.google.com/config-connector/docs/reference/resource-docs/container/containercluster)
+- [GKEHubFeatureMembership](https://cloud.google.com/config-connector/docs/reference/resource-docs/gkehub/gkehubfeaturemembership)
+- [GKEHubMembership](https://cloud.google.com/config-connector/docs/reference/resource-docs/gkehub/gkehubmembership)
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [IAMServiceAccount](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount)
+- [KMSCryptoKey](https://cloud.google.com/config-connector/docs/reference/resource-docs/kms/kmscryptokey)
+- [KMSKeyRing](https://cloud.google.com/config-connector/docs/reference/resource-docs/kms/kmskeyring)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/gke/configconnector/gke-cluster-autopilot@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd "./gke-cluster-autopilot/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/gke/configconnector/gke-cluster-autopilot/application-infrastructure-folder/firewall.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/application-infrastructure-folder/firewall.yaml
@@ -1,0 +1,105 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+########
+# GKE egress Allow GKE nodes to AzDO
+# TODO: validate if service account can be used instead of podipv4range
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeFirewallPolicyRule
+metadata:
+  name: project-id-cluster-name-egress-allow-azdo # kpt-set: ${project-id}-${cluster-name}-egress-allow-azdo
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+spec:
+  action: "allow"
+  description: "GKE allow access to dev.azure.com"
+  direction: "EGRESS"
+  disabled: false
+  enableLogging: true
+  firewallPolicyRef:
+    name: client-name-standard-applications-infrastructure-fwpol # kpt-set: ${client-name}-standard-applications-infrastructure-fwpol
+    namespace: client-name-networking # kpt-set: ${client-name}-networking
+  match:
+    srcIPRanges: # kpt-set: ${primaryIpv4Range}
+      - primaryIpv4Range
+    layer4Configs:
+      - ipProtocol: "tcp"
+        ports:
+          - "443"
+    destFqdns:
+      - "dev.azure.com"
+  priority: 2000 # kpt-set: ${gke-to-azdo-priority}
+  # targetServiceAccounts:
+  #     - name: cluster-name-sa # kpt-set: ${cluster-name}-sa
+---
+# GKE egress Allow GKE nodes to Github
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeFirewallPolicyRule
+metadata:
+  name: project-id-cluster-name-egress-allow-github # kpt-set: ${project-id}-${cluster-name}-egress-allow-github
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+spec:
+  action: "allow"
+  description: "GKE allow access to github.com"
+  direction: "EGRESS"
+  disabled: false
+  enableLogging: true
+  firewallPolicyRef:
+    name: client-name-standard-applications-infrastructure-fwpol # kpt-set: ${client-name}-standard-applications-infrastructure-fwpol
+    namespace: client-name-networking # kpt-set: ${client-name}-networking
+  match:
+    srcIPRanges: # kpt-set: ${primaryIpv4Range}
+      - primaryIpv4Range
+    layer4Configs:
+      - ipProtocol: "tcp"
+        ports:
+          - "443"
+    destFqdns:
+      - "github.com"
+  priority: 2001 # kpt-set: ${gke-to-github-priority}
+  # targetServiceAccounts:
+  #     - name: cluster-name-sa # kpt-set: ${cluster-name}-sa
+---
+# GKE egress Allow GKE nodes to docker registry
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeFirewallPolicyRule
+metadata:
+  name: project-id-cluster-name-egress-allow-docker # kpt-set: ${project-id}-${cluster-name}-egress-allow-docker
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+spec:
+  action: "allow"
+  description: "GKE allow access to docker.pkg.dev"
+  direction: "EGRESS"
+  disabled: false
+  enableLogging: true
+  firewallPolicyRef:
+    name: client-name-standard-applications-infrastructure-fwpol # kpt-set: ${client-name}-standard-applications-infrastructure-fwpol
+    namespace: client-name-networking # kpt-set: ${client-name}-networking
+  match:
+    srcIPRanges: # kpt-set: ${primaryIpv4Range}
+      - primaryIpv4Range
+    layer4Configs:
+      - ipProtocol: "tcp"
+        ports:
+          - "443"
+    destFqdns:
+      - "northamerica-northeast1-docker.pkg.dev"
+      - "northamerica-northeast2-docker.pkg.dev"
+  priority: 2002 # kpt-set: ${gke-to-docker-priority}
+  # targetServiceAccounts:
+  #     - name: cluster-name-sa # kpt-set: ${cluster-name}-sa

--- a/solutions/gke/configconnector/gke-cluster-autopilot/gke.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/gke.yaml
@@ -1,0 +1,87 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# GKE Autopilot Cluster
+# https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: autopilot1-gke # kpt-set: ${cluster-name}
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    cnrm.cloud.google.com/state-into-spec: absent
+spec:
+  addonsConfig:
+    configConnectorConfig:
+      enabled: false
+  clusterAutoscaling:
+    enabled: true
+    autoProvisioningDefaults:
+      serviceAccountRef:
+        name: cluster-name-sa # kpt-set: ${cluster-name}-sa
+  description: GKE Autopilot Cluster
+  databaseEncryption:
+    keyName: projects/project-id/locations/northamerica-northeast1/keyRings/cluster-name-kmskeyring/cryptoKeys/cluster-name-etcd-key # kpt-set: projects/${project-id}/locations/${location}/keyRings/${cluster-name}-kmskeyring/cryptoKeys/${cluster-name}-etcd-key
+    state: ENCRYPTED
+  enableAutopilot: true
+  # binaryAuthorization:
+  #   evaluationMode: PROJECT_SINGLETON_POLICY_ENFORCE
+  # With IntranodeVisibility, pod-to-pod traffic is sent to the VPC. Autopilot clusters must have intranode visibility enabled
+  enableIntranodeVisibility: true
+  gatewayApiConfig:
+    channel: CHANNEL_STANDARD
+  initialNodeCount: 1
+  ipAllocationPolicy:
+    clusterSecondaryRangeName: podrange
+    servicesSecondaryRangeName: servicesrange
+  location: northamerica-northeast1 # kpt-set: ${location}
+  loggingConfig:
+    enableComponents:
+      - "SYSTEM_COMPONENTS"
+      - "WORKLOADS"
+  maintenancePolicy:
+    # GMT timezone
+    dailyMaintenanceWindow:
+      startTime: 05:00
+      duration: 04:00
+  masterAuthorizedNetworksConfig:
+    cidrBlocks: # kpt-set: ${master-authorized-networks-cidr}
+      - cidrBlock: 10.1.1.5/32
+        displayName: bastion
+  monitoringConfig:
+    enableComponents:
+      - "SYSTEM_COMPONENTS"
+  networkRef:
+    name: host-project-vpc # kpt-set: ${host-project-vpc}
+    namespace: client-name-networking # kpt-set: ${client-name}-networking
+  networkingMode: VPC_NATIVE
+  notificationConfig:
+    pubsub:
+      enabled: true
+      topicRef:
+        name: project-id-gke-cluster-notification-pubsub-topic # kpt-set: ${project-id}-gke-cluster-notification-pubsub-topic
+        namespace: client-name-logging # kpt-set: ${client-name}-logging
+  podSecurityPolicyConfig:
+    enabled: false
+  privateClusterConfig:
+    enablePrivateEndpoint: true
+    enablePrivateNodes: true
+    masterIpv4CidrBlock: 172.16.0.0/28 # kpt-set: ${masterIpv4CidrBlock}
+  releaseChannel:
+    channel: REGULAR
+  subnetworkRef:
+    name: project-id-cluster-name-snet # kpt-set: ${project-id}-${cluster-name}-snet
+  verticalPodAutoscaling:
+    enabled: true

--- a/solutions/gke/configconnector/gke-cluster-autopilot/gke.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/gke.yaml
@@ -17,7 +17,7 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerCluster
 metadata:
-  name: autopilot1-gke # kpt-set: ${cluster-name}
+  name: cluster-name # kpt-set: ${cluster-name}
   namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}

--- a/solutions/gke/configconnector/gke-cluster-autopilot/gkehub-featuremembership-acm.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/gkehub-featuremembership-acm.yaml
@@ -1,0 +1,49 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Anthos Config Management
+apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
+kind: GKEHubFeatureMembership
+metadata:
+  name: cluster-name-acm-hubfeaturemembership # kpt-set: ${cluster-name}-acm-hubfeaturemembership
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+spec:
+  projectRef:
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  location: global
+  membershipRef:
+    name: cluster-name # kpt-set: ${cluster-name}
+  featureRef:
+    name: project-id-acm-hubfeature # kpt-set: ${project-id}-acm-hubfeature
+  configmanagement:
+    binauthz:
+      enabled: false
+    configSync:
+      sourceFormat: unstructured
+      # TODO: validate with ACM product team: this appears to be deprecated since May 15 2023
+      # https://cloud.google.com/anthos-config-management/docs/configmanagement-fields#configuration_for_git_repositories
+      git:
+        syncRepo: "https://AZDO-ORG@dev.azure.com/AZDO-ORG/AZDO-PROJECT/_git/REPO-NAME" # kpt-set: ${repo-url}
+        syncBranch: "main" # kpt-set: ${repo-branch}
+        policyDir: csync/tier3/kubernetes/<fleet-id>/deploy/<env> # kpt-set: ${repo-dir}
+        syncWaitSecs: "20"
+        syncRev: "HEAD"
+        secretType: "token"
+    policyController:
+      enabled: true
+      referentialRulesEnabled: true
+      logDeniesEnabled: true
+      templateLibraryInstalled: true
+      auditIntervalSeconds: "60"

--- a/solutions/gke/configconnector/gke-cluster-autopilot/gkehub-membership.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/gkehub-membership.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Register a cluster to a fleet
+# https://cloud.google.com/anthos/fleet-management/docs/register/gke
+apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
+kind: GKEHubMembership
+metadata:
+  name: cluster-name # kpt-set: ${cluster-name}
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  location: global
+  endpoint:
+    gkeCluster:
+      resourceRef:
+        name: cluster-name # kpt-set: ${cluster-name}
+  authority:
+    issuer: https://container.googleapis.com/v1/projects/project-id/locations/northamerica-northeast1/clusters/cluster-name # kpt-set: https://container.googleapis.com/v1/projects/${project-id}/locations/${location}/clusters/${cluster-name}

--- a/solutions/gke/configconnector/gke-cluster-autopilot/host-project/firewall.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/host-project/firewall.yaml
@@ -1,0 +1,33 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Firewall rule for lb health check
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeFirewall
+metadata:
+  name: project-id-cluster-name-lb-health-check # kpt-set: ${project-id}-${cluster-name}-lb-health-check
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+spec:
+  resourceID: project-id-cluster-name-lb-health-check # kpt-set: ${project-id}-${cluster-name}-lb-health-check
+  allow:
+    - protocol: tcp
+  networkRef:
+    name: host-project-id-global-standard-vpc # kpt-set: ${host-project-id}-global-standard-vpc
+    namespace: client-name-networking # kpt-set: ${client-name}-networking
+  sourceRanges:
+    - "35.191.0.0/16"
+    - "130.211.0.0/22"
+  destinationRanges: # kpt-set: ${podIpv4Range}
+    - podIpv4Range

--- a/solutions/gke/configconnector/gke-cluster-autopilot/host-project/subnet.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/host-project/subnet.yaml
@@ -1,0 +1,48 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# subnet has :
+# - logging enabled for flow logs https://cloud.google.com/vpc/docs/using-flow-logs
+# - private google access enabled https://cloud.google.com/vpc/docs/private-google-access
+#########
+# GKE Subnet
+# AC-4, AC-4(21)
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: project-id-cluster-name-snet # kpt-set: ${project-id}-${cluster-name}-snet
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+spec:
+  resourceID: project-id-cluster-name-snet # kpt-set: ${project-id}-${cluster-name}-snet
+  ipCidrRange: 10.1.32.0/24 # kpt-set: ${subnet-primary-cidr}
+  # Notes about secondary ranges
+  # You can create 30 secondary ranges in a given subnet. For each cluster, you need two secondary ranges: one for Pods and one for Services.
+  # Note: The primary range and the Pod secondary range can be shared between clusters, but this is not a recommended configuration
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#notes_about_secondary_ranges
+  secondaryIpRange:
+    - ipCidrRange: 10.1.33.0/24 # kpt-set: ${subnet-services-cidr}
+      rangeName: servicesrange
+    - ipCidrRange: 240.1.0.0/21 # kpt-set: ${subnet-pod-cidr}
+      rangeName: podrange
+  region: northamerica-northeast1 # kpt-set: ${location}
+  description: GKE Subnet
+  privateIpGoogleAccess: true
+  networkRef:
+    name: host-project-vpc # kpt-set: ${host-project-vpc}
+    namespace: client-name-networking # kpt-set: ${client-name}-networking
+  logConfig:
+    aggregationInterval: INTERVAL_5_SEC
+    flowSampling: 0.5
+    metadata: INCLUDE_ALL_METADATA

--- a/solutions/gke/configconnector/gke-cluster-autopilot/kms.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/kms.yaml
@@ -1,0 +1,36 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Cloud KMS Key Ring and Key for GKE ETCD Encryption
+apiVersion: kms.cnrm.cloud.google.com/v1beta1
+kind: KMSKeyRing
+metadata:
+  name: cluster-name-kmskeyring # kpt-set: ${cluster-name}-kmskeyring
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  location: northamerica-northeast1 # kpt-set: ${location}
+---
+apiVersion: kms.cnrm.cloud.google.com/v1beta1
+kind: KMSCryptoKey
+metadata:
+  name: cluster-name-etcd-key # kpt-set: ${cluster-name}-etcd-key
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  keyRingRef:
+    name: cluster-name-kmskeyring # kpt-set: ${cluster-name}-kmskeyring
+  purpose: ENCRYPT_DECRYPT

--- a/solutions/gke/configconnector/gke-cluster-autopilot/securitycontrols.md
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/securitycontrols.md
@@ -1,0 +1,17 @@
+# Security Controls
+
+<!-- BEGINNING OF SECURITY CONTROLS LIST -->
+|Security Control|File Name|Resource Name|
+|---|---|---|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-artifactregistry-reader-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-logwriter-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-metricwriter-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-monitoring-viewer-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-secretmanager-secretaccessor-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-stackdriver-metadata-writer-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-storage-object-viewer-permissions|
+|AC-3(7)|./service-account.yaml|project-id-tier3-sa-serviceaccount-user-cluster-name-sa-permissions|
+|AC-4|./host-project/subnet.yaml|project-id-cluster-name-snet|
+|AC-4(21)|./host-project/subnet.yaml|project-id-cluster-name-snet|
+
+<!-- END OF SECURITY CONTROLS LIST -->

--- a/solutions/gke/configconnector/gke-cluster-autopilot/service-account.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/service-account.yaml
@@ -1,0 +1,189 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# GCP SA
+# CIS GKE Benchmark Recommendation: 6.2.1. Prefer not running GKE clusters using the Compute Engine default service account
+# https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: cluster-name-sa # kpt-set: ${cluster-name}-sa
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  displayName: cluster-name-sa # kpt-set: ${cluster-name}-sa
+---
+# Grant GCP role Logging Log Writer to GCP SA on Service Project
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: cluster-name-sa-logwriter-permissions # kpt-set: ${cluster-name}-sa-logwriter-permissions
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/logging.logWriter
+  member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant GCP role Monitoring Metric Writer to GCP SA on Service Project
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: cluster-name-sa-metricwriter-permissions # kpt-set: ${cluster-name}-sa-metricwriter-permissions
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/monitoring.metricWriter
+  member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant GCP role Monitoring Viewer to GCP SA on Service Project
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: cluster-name-sa-monitoring-viewer-permissions # kpt-set: ${cluster-name}-sa-monitoring-viewer-permissions
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/monitoring.viewer
+  member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant GCP Storage Object Viewer to GCP SA on Service Project for Artifact Registry access
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: cluster-name-sa-storage-object-viewer-permissions # kpt-set: ${cluster-name}-sa-storage-object-viewer-permissions
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/storage.objectViewer
+  member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant stackdriver.resourceMetadata.writer to GCP SA on Service Project for Logging access
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: cluster-name-sa-stackdriver-metadata-writer-permissions # kpt-set: ${cluster-name}-a-stackdriver-metadata-writer-permissions
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/stackdriver.resourceMetadata.writer
+  member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant artifactregistry.reader to GCP SA on Service Project for Artifact Registry access
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: cluster-name-sa-artifactregistry-reader-permissions # kpt-set: ${cluster-name}-sa-artifactregistry-reader-permissions
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/artifactregistry.reader
+  member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant secretmanager.secretAccessor to GCP SA on Service Project for Secret access
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: cluster-name-sa-secretmanager-secretaccessor-permissions # kpt-set: ${cluster-name}-sa-secretmanager-secretaccessor-permissions
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: project-id # kpt-set: ${project-id}
+    namespace: client-name-projects # kpt-set: ${client-name}-projects
+  role: roles/secretmanager.secretAccessor
+  member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
+---
+
+# TODO: activate once the service account can be used by the control plane
+# # Grant cloudkms.cryptoKeyEncrypterDecrypter to GCP SA on Service Project for Cloud KMS access
+# # AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# apiVersion: iam.cnrm.cloud.google.com/v1beta1
+# kind: IAMPolicyMember
+# metadata:
+#   name: cluster-name-sa-cloudkms-encrypterdecrypter-permissions # kpt-set: ${cluster-name}-sa-cloudkms-encrypterdecrypter-permissions
+#   namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+#   annotations:
+#     cnrm.cloud.google.com/ignore-clusterless: "true"
+# spec:
+#   resourceRef:
+#     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+#     kind: Project
+#     name: project-id # kpt-set: ${project-id}
+#     namespace: client-name-projects # kpt-set: ${client-name}-projects
+#   role: roles/cloudkms.cryptoKeyEncrypterDecrypter
+#   member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
+---
+# Grant IAM service account user to Tier3 SA on cluster-name SA
+# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-tier3-sa-serviceaccount-user-cluster-name-sa-permissions # kpt-set: ${project-id}-tier3-sa-serviceaccount-user-${cluster-name}-sa-permissions
+  namespace: project-id-tier3 # kpt-set: ${project-id}-tier3
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: cluster-name-sa # kpt-set: ${cluster-name}-sa
+  role: roles/iam.serviceAccountUser
+  member: "serviceAccount:tier3-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:tier3-sa@${project-id}.iam.gserviceaccount.com

--- a/solutions/gke/configconnector/gke-cluster-autopilot/service-account.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/service-account.yaml
@@ -151,7 +151,6 @@ spec:
   role: roles/secretmanager.secretAccessor
   member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
 ---
-
 # TODO: activate once the service account can be used by the control plane
 # # Grant cloudkms.cryptoKeyEncrypterDecrypter to GCP SA on Service Project for Cloud KMS access
 # # AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
@@ -170,7 +169,7 @@ spec:
 #     namespace: client-name-projects # kpt-set: ${client-name}-projects
 #   role: roles/cloudkms.cryptoKeyEncrypterDecrypter
 #   member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
----
+#---
 # Grant IAM service account user to Tier3 SA on cluster-name SA
 # AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
 apiVersion: iam.cnrm.cloud.google.com/v1beta1

--- a/solutions/gke/configconnector/gke-cluster-autopilot/service-account.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/service-account.yaml
@@ -169,7 +169,7 @@ spec:
 #     namespace: client-name-projects # kpt-set: ${client-name}-projects
 #   role: roles/cloudkms.cryptoKeyEncrypterDecrypter
 #   member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
-#---
+# ---
 # Grant IAM service account user to Tier3 SA on cluster-name SA
 # AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
 apiVersion: iam.cnrm.cloud.google.com/v1beta1

--- a/solutions/gke/configconnector/gke-cluster-autopilot/setters.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/setters.yaml
@@ -1,0 +1,100 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  #
+  ##########################
+  # Cient
+  ##########################
+  #
+  # Name for the client, lowercase only
+  client-name: client1
+  #
+  ##########################
+  # Project
+  ##########################
+  #
+  # The project id that was created by the client-project-setup. This id will also becomes the Anthos Fleet id
+  project-id: project-12345
+  #
+  ##########################
+  # Network Host Project
+  ##########################
+  #
+  # the client network host project id
+  host-project-id: host-project-12345
+  # VPC to deploy the subnet - K8S resource name
+  host-project-vpc: host-project-vpc
+  #
+  ##########################
+  # GKE
+  ##########################
+  #
+  # name of this GKE cluster
+  cluster-name: autopilot1-gke
+  # the region where to deploy this GKE cluster
+  location: northamerica-northeast1
+  # the master control plane cidr for kind ContainerCluster
+  masterIpv4CidrBlock: 172.16.0.0/28
+  # the master control plane range for kind ComputeFirewall (same as masterIpv4CidrBlock but using list)
+  masterIpv4Range: |
+    - "172.16.0.0/28"
+  # the master authorized networks cidr - bastion ip
+  master-authorized-networks-cidr: |
+    - cidrBlock: 10.1.1.5/32
+      displayName: bastion
+  # subnet IP ranges
+  subnet-primary-cidr: 10.1.32.0/24
+  subnet-services-cidr: 10.1.33.0/24
+  subnet-pod-cidr: 240.1.0.0/21
+  # the pod range for kind ComputeFirewall (same as subnet-pod-cidr but using list)
+  podIpv4Range: |
+    - "240.1.0.0/21"
+  # the primary range for kind ComputeFirewall (same as subnet-primary-cidr but using list)
+  primaryIpv4Range: |
+    - "10.1.32.0/24"
+  # firewall policies priority ( cannot overlap with any existing policy id)
+  gke-to-azdo-priority: 2000
+  gke-to-github-priority: 2001
+  gke-to-docker-priority: 2002
+  #
+  ##########################
+  # Config Sync
+  ##########################
+  #
+  # Used for the initial root sync of the GKE cluster (GitHub, Azure DevOps, etc.)
+  #
+  # the git repo URL, for example
+  # https://github.com/GITHUB-ORG/REPO-NAME
+  # https://AZDO-ORG@dev.azure.com/AZDO-ORG/AZDO-PROJECT/_git/REPO-NAME
+  repo-url: tier34-repo-to-observe
+  # the branch to check out (usually main)
+  repo-branch: main
+  # the directory to observe for YAML manifests
+  repo-dir: csync/tier3/kubernetes/<fleet-id>/deploy/<env>
+  #
+  ##########################
+  # End of Configurations
+  ##########################


### PR DESCRIPTION
Landing zone v2 subpackage.
Depends on package `gke-setup`.
Requires project-id-tier3 namespace.

Deploy this package once per GKE cluster.

A GKE Autopilot Cluster running in a service project. This package also deploys a dedicated subnet inside the host project.
- firewall policy rules to allow traffic toward github, azdo and docker registry
- subnet in host project
- gke cluster
- anthos fleet
- anthos config management
- kms key for etcd encryption
- service account with least privilege roles

This package contributes to the solution for #479 