### PR TITLE
feat: kubernetes default package

### DIFF
--- a/solutions/gke/kubernetes/cluster-defaults/Kptfile
+++ b/solutions/gke/kubernetes/cluster-defaults/Kptfile
@@ -1,0 +1,14 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: cluster-defaults
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    Landing zone v2 subpackage.
+    Depends on package `gke-cluster-autopilot`.
+    This package deploys to a GKE cluster.
+    It should be deployed once per cluster.
+
+    This package deploys default resources that have to exist on all clusters.

--- a/solutions/gke/kubernetes/cluster-defaults/README.md
+++ b/solutions/gke/kubernetes/cluster-defaults/README.md
@@ -1,0 +1,17 @@
+# Cluster Defaults
+
+Landing zone v2 subpackage.
+Depends on package `gke-cluster-autopilot`.
+This package deploys to a GKE cluster.
+It should be deployed once per cluster.
+
+This package deploys default resources that have to exist on all clusters.
+
+---
+Resources list:
+
+- Gateway Controller
+  - gateway namespace
+  - Gateway using an external global load balancer and a SSL certificate
+  - Attaches an SSL Policy
+  - Attaches a Cloud Armor and logging policy

--- a/solutions/gke/kubernetes/cluster-defaults/README.md
+++ b/solutions/gke/kubernetes/cluster-defaults/README.md
@@ -11,7 +11,7 @@ This package deploys default resources that have to exist on all clusters.
 Resources list:
 
 - Gateway Controller
-  - gateway namespace
+  - Gateway namespace
   - Gateway using an external global load balancer and a SSL certificate
   - Attaches an SSL Policy
   - Attaches a Cloud Armor and logging policy

--- a/solutions/gke/kubernetes/cluster-defaults/admin-namespaces/gateway.yaml
+++ b/solutions/gke/kubernetes/cluster-defaults/admin-namespaces/gateway.yaml
@@ -1,0 +1,19 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Namespace for the gateway resources
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway-infra

--- a/solutions/gke/kubernetes/cluster-defaults/gateway/Kptfile
+++ b/solutions/gke/kubernetes/cluster-defaults/gateway/Kptfile
@@ -1,0 +1,18 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: gateway
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    Landing zone v2 subpackage.
+    Depends on package `gke-defaults` and `ssl-policies`.
+    This package deploys to a GKE cluster.
+    It should be deployed once per gateway resource. You can have multiple copies of this subpackage by cloning the entire folder to a new folder (i.e. subpackage2)
+
+    This package deploys a gateway resource (Gateway Controller) and attach it a TLS 1.2 SSL policy approved by TBS.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/gke/kubernetes/cluster-defaults/gateway/backendpolicy/Kptfile
+++ b/solutions/gke/kubernetes/cluster-defaults/gateway/backendpolicy/Kptfile
@@ -1,0 +1,18 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: backendpolicy
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    Landing zone v2 subpackage.
+    Depends on package `cloud-armor` and a kubernetes service.
+    This package deploys to a GKE cluster.
+    It should be deployed once per kubernetes service exposed to the internet. You can have multiple copies of this subpackage by cloning the entire folder to a new folder (i.e. subpackage2)
+
+    This package deploys GCPBackendPolicy to attach a cloud armor policy and logging specification to a kubernetes service.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/gke/kubernetes/cluster-defaults/gateway/backendpolicy/backendpolicy.yaml
+++ b/solutions/gke/kubernetes/cluster-defaults/gateway/backendpolicy/backendpolicy.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Cloud Armor Policy with logging enabled for backend service
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  name: workload-name-cloud-armor # kpt-set: ${workload-name}-cloud-armor
+  namespace: workload-name # kpt-set: ${workload-name}
+spec:
+  default:
+    securityPolicy: workload-name-security-policy # kpt-set: ${workload-name}-security-policy
+    logging:
+      enabled: true
+      sampleRate: 500000 # specifies that 50% of packets are logged. You can use a value between 0 and 1,000,000. GKE converts this value to a floating point value in the range [0, 1] by dividing by 1,000,000.
+  targetRef:
+    group: ""
+    kind: Service
+    name: service-name # kpt-set: ${service-name}

--- a/solutions/gke/kubernetes/cluster-defaults/gateway/backendpolicy/setters.yaml
+++ b/solutions/gke/kubernetes/cluster-defaults/gateway/backendpolicy/setters.yaml
@@ -1,0 +1,35 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  ##########################
+  # Workload
+  ##########################
+  workload-name: sample-workload
+  service-name: sample-service
+  #
+  ##########################
+  # End of Configurations
+  ##########################

--- a/solutions/gke/kubernetes/cluster-defaults/gateway/gateway-global.yaml
+++ b/solutions/gke/kubernetes/cluster-defaults/gateway/gateway-global.yaml
@@ -1,0 +1,39 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Gateway using an external global load balancer and a SSL certificate
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: external-gateway-name # kpt-set: external-${gateway-name}
+  namespace: gateway-infra
+spec:
+  gatewayClassName: gke-l7-global-external-managed
+  addresses:
+    - type: NamedAddress
+      value: gateway-name-compute-address # kpt-set: ${gateway-name}-compute-address
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        options:
+          networking.gke.io/pre-shared-certs: sample-cert # kpt-set: ${ssl-cert}
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              shared-gateway-access: "true"

--- a/solutions/gke/kubernetes/cluster-defaults/gateway/gateway-regional.yaml
+++ b/solutions/gke/kubernetes/cluster-defaults/gateway/gateway-regional.yaml
@@ -1,0 +1,42 @@
+# # Copyright 2021 Google LLC
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #      http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+# #########
+# # Gateway using an external regional load balancer and a SSL certificate
+# # TODO: This gives an error; It tries to deploy it to <project>/network/default VPC instead of the cluster VPC
+# # and Google-managed SSL certificates are not compatible with regional Gateways.
+# apiVersion: gateway.networking.k8s.io/v1beta1
+# kind: Gateway
+# metadata:
+#   name: external-gateway-name # kpt-set: external-${gateway-name}
+#   namespace: gateway-infra
+# spec:
+#   gatewayClassName: gke-l7-regional-external-managed
+#   addresses:
+#   - type: NamedAddress
+#     value: gateway-name-compute-address # kpt-set: ${gateway-name}-compute-address
+#   listeners:
+#   - name: https
+#     protocol: HTTPS
+#     port: 443
+#     tls:
+#       mode: Terminate
+#       options:
+#         networking.gke.io/pre-shared-certs: sample-cert # kpt-set: ${ssl-cert}
+#     allowedRoutes:
+#       namespaces:
+#         from: Selector
+#         selector:
+#           matchLabels:
+#             shared-gateway-access: "true"
+

--- a/solutions/gke/kubernetes/cluster-defaults/gateway/gcpgatewaypolicy.yaml
+++ b/solutions/gke/kubernetes/cluster-defaults/gateway/gcpgatewaypolicy.yaml
@@ -1,0 +1,27 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Assign SSL policy to gateway
+apiVersion: networking.gke.io/v1
+kind: GCPGatewayPolicy
+metadata:
+  name: external-gateway-name-policy # kpt-set: external-${gateway-name}-policy
+  namespace: gateway-infra
+spec:
+  default:
+    sslPolicy: ssl-policy # kpt-set: ${ssl-policy}
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: external-gateway-name # kpt-set: external-${gateway-name}

--- a/solutions/gke/kubernetes/cluster-defaults/gateway/setters.yaml
+++ b/solutions/gke/kubernetes/cluster-defaults/gateway/setters.yaml
@@ -1,0 +1,38 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  #
+  ##########################
+  # Gateway
+  ##########################
+  #
+  gateway-name: sample-gateway
+  ssl-policy: tls-1-2-computesslpolicy
+  ssl-cert: sample-cert
+  #
+  ##########################
+  # End of Configurations
+  ##########################

--- a/solutions/gke/kubernetes/cluster-defaults/securitycontrols.md
+++ b/solutions/gke/kubernetes/cluster-defaults/securitycontrols.md
@@ -1,0 +1,7 @@
+# Security Controls
+
+<!-- BEGINNING OF SECURITY CONTROLS LIST -->
+|Security Control|File Name|Resource Name|
+|---|---|---|
+
+<!-- END OF SECURITY CONTROLS LIST -->


### PR DESCRIPTION
This package deploys to a GKE cluster.
It should be deployed once per cluster.

This package deploys default resources that have to exist on all clusters.

---
Resources list:

- Gateway Controller
  - gateway namespace
  - Gateway using an external global load balancer and a SSL certificate
  - Attaches an SSL Policy
  - Attaches a Cloud Armor and logging policy
 
contributes to #479 