### PR TITLE
feat: kubernetes namespace defaults package

### DIFF
--- a/solutions/gke/kubernetes/namespace-defaults/Kptfile
+++ b/solutions/gke/kubernetes/namespace-defaults/Kptfile
@@ -1,0 +1,18 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: namespace-defaults
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    Landing zone v2 subpackage.
+    Depends on package `cluster-defaults`.
+    This package deploys to a GKE cluster.
+    It should be deployed once per workload namespace.
+
+    This package deploys a workload namespace and it's associated configuration.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/gke/kubernetes/namespace-defaults/README.md
+++ b/solutions/gke/kubernetes/namespace-defaults/README.md
@@ -1,0 +1,18 @@
+# Namepsace Defaults
+
+Landing zone v2 subpackage.
+Depends on package `cluster-defaults`.
+This package deploys to a GKE cluster.
+It should be deployed once per workload namespace.
+
+This package deploys a workload namespace and it's associated configuration.
+
+---
+Resources list:
+
+- namespace
+- resourcequota
+- limitrange
+- networkpolicies
+- rolebinding for an application team
+- a choice of Continuous Delivery(CD) solution which offer ConfigSync (Default) or ServiceAccount permission for external tools.

--- a/solutions/gke/kubernetes/namespace-defaults/cd/cd-rolebinding.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/cd/cd-rolebinding.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Grant edit role to a Continuous Delivery Google service account
+# To be enabled when deploying using other solution than configsync
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: RoleBinding
+# metadata:
+#   name: cicd-edit-rolebinding
+#   namespace: workload-name # kpt-set: ${workload-name}
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: Role
+#   name: edit
+# subjects:
+# - apiGroup: rbac.authorization.k8s.io
+#   kind: User
+#   name: sample-google-account # TODO this needs to be set in setters e.g. service-account1@test-project.iam.gserviceaccount.com
+

--- a/solutions/gke/kubernetes/namespace-defaults/cd/gitops-config-sync.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/cd/gitops-config-sync.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Root Sync to observe foler csync/tier4/kubernetes/<fleet-id>/deploy/env/<namespace>
+apiVersion: configsync.gke.io/v1beta1
+kind: RootSync
+metadata:
+  # namespace + "_" + name cannot exceed 63 characters
+  name: workload-name-t4-csync # kpt-set: ${workload-name}-t4-csync
+  namespace: config-management-system
+spec:
+  sourceFormat: unstructured
+  git:
+    repo: https://repo-url # kpt-set: ${repo-url}
+    branch: main # kpt-set: ${repo-branch}
+    dir: csync/tier4/kubernetes/<fleet-id>/deploy/env/<namespace> # kpt-set: ${repo-dir}
+    revision: HEAD
+    auth: token
+    secretRef:
+      name: git-creds

--- a/solutions/gke/kubernetes/namespace-defaults/limitrange.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/limitrange.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Sets resource usage limits for each kind of resource in a Namespace
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: workload-name # kpt-set: ${workload-name}
+spec:
+  limits:
+    - max:
+        cpu: "800m"
+        memory: "2Gi"
+      min:
+        cpu: "10m"
+        memory: "200Mi"
+      defaultRequest:
+        cpu: "200m"
+        memory: "200Mi"
+      type: Container

--- a/solutions/gke/kubernetes/namespace-defaults/namespace.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/namespace.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Workload namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workload-name # kpt-set: ${workload-name}
+  labels:
+    shared-gateway-access: "true" # Needed for shared Gateway
+# TODO: to be replaced by gatekeeper constraints
+# pod-security.kubernetes.io/warn: restricted

--- a/solutions/gke/kubernetes/namespace-defaults/networkpolicy.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/networkpolicy.yaml
@@ -1,0 +1,104 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Network Policies
+# Allow ingress within namespace
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: workload-name # kpt-set: ${workload-name}
+  name: allow-ingress-within-namespace
+spec:
+  podSelector: {}
+  ingress:
+    # From all pods within the same namespace
+    - from:
+        - podSelector: {}
+---
+# Allow ingress from gateway namespace.
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: workload-name # kpt-set: ${workload-name}
+  name: allow-ingress-from-gateway
+spec:
+  podSelector: {}
+  ingress:
+    # From gateway namespace
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-infra
+---
+# Allow ingress from lb health check
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: workload-name # kpt-set: ${workload-name}
+  name: allow-ingress-from-lb-health-check
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 35.191.0.0/16
+    - from:
+        - ipBlock:
+            cidr: 130.211.0.0/22
+    - from:
+        - ipBlock:
+            cidr: 209.85.152.0/22
+    - from:
+        - ipBlock:
+            cidr: 209.85.204.0/22
+---
+# Allow egress within namespace
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: workload-name # kpt-set: ${workload-name}
+  name: allow-egress-within-namespace
+spec:
+  podSelector: {}
+  egress:
+    # To all pods within the same namespace
+    - to:
+        - podSelector: {}
+---
+# Allow egress to metadata server
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: workload-name # kpt-set: ${workload-name}
+  name: allow-egress-to-metadata-server
+spec:
+  podSelector: {}
+  egress:
+    # Network policy and Workload Identity
+    # For clusters running GKE version 1.21.0-gke.1000 and later, allow egress to 169.254.169.252/32 on port 988
+    # For clusters running GKE Dataplane V2, allow egress to 169.254.169.254/32 on port 80
+    - to:
+        - ipBlock:
+            cidr: 169.254.169.252/32
+      ports:
+        - port: 988
+    - to:
+        - ipBlock:
+            cidr: 169.254.169.254/32
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        - port: 80

--- a/solutions/gke/kubernetes/namespace-defaults/resourcequota.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/resourcequota.yaml
@@ -1,0 +1,27 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Sets aggregate quota restrictions enforced per namespace
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: resource-quota
+  namespace: workload-name # kpt-set: ${workload-name}
+spec:
+  hard:
+    requests.cpu: "1"
+    requests.memory: 2Gi
+    limits.cpu: "2"
+    limits.memory: 4Gi
+    pods: 10

--- a/solutions/gke/kubernetes/namespace-defaults/rolebinding-httproute-admin.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/rolebinding-httproute-admin.yaml
@@ -1,0 +1,48 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Role to manage routes in the workload namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: httproute-admin-role
+  namespace: workload-name # kpt-set: ${workload-name}
+rules:
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - create
+      - update
+      - delete
+---
+# Grant httproute admin role to ns-reconciler-workload-name
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: httproute-admin-rolebinding
+  namespace: workload-name # kpt-set: ${workload-name}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: httproute-admin-role
+subjects:
+  - kind: ServiceAccount
+    name: ns-reconciler-workload-name # kpt-set: ns-reconciler-${workload-name}
+    namespace: config-management-system

--- a/solutions/gke/kubernetes/namespace-defaults/rolebinding-team-view.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/rolebinding-team-view.yaml
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Grant view access to user or group
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: team-view-rolebinding
+  namespace: workload-name # kpt-set: ${workload-name}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: view
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: workload-view # kpt-set: ${workload-view}

--- a/solutions/gke/kubernetes/namespace-defaults/securitycontrols.md
+++ b/solutions/gke/kubernetes/namespace-defaults/securitycontrols.md
@@ -1,0 +1,7 @@
+# Security Controls
+
+<!-- BEGINNING OF SECURITY CONTROLS LIST -->
+|Security Control|File Name|Resource Name|
+|---|---|---|
+
+<!-- END OF SECURITY CONTROLS LIST -->

--- a/solutions/gke/kubernetes/namespace-defaults/setters.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/setters.yaml
@@ -1,0 +1,59 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  ##########################
+  # Client
+  ##########################
+  #
+  # Name for the client, lowercase only
+  client-name: 'client1'
+  #
+  ##########################
+  # Application
+  ##########################
+  #
+  workload-name: sample-workload
+  workload-billing-id: sample-id
+  workload-owner: sample-owner
+  workload-contact-info: sample-owner@sample.email
+  # user or group to grant view role on workload namespace
+  workload-view: 'group:client1@example.com'
+  #
+  ##########################
+  # Config Sync
+  ##########################
+  # the git repo URL, for example
+  # https://github.com/GITHUB-ORG/REPO-NAME
+  # https://AZDO-ORG@dev.azure.com/AZDO-ORG/AZDO-PROJECT/_git/REPO-NAME
+  repo-url: git-repo-to-observe
+  # the branch to check out (usually main)
+  repo-branch: main
+  # the directory to observe for YAML manifests
+  repo-dir: csync/tier4/kubernetes/<fleet-id>/deploy/env/<namespace>
+  #
+  ##########################
+  # End of Configurations
+  ##########################

--- a/solutions/gke/kubernetes/namespace-defaults/setters.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/setters.yaml
@@ -35,10 +35,8 @@ data:
   # Application
   ##########################
   #
+  # the name of the workload, lowercase only
   workload-name: sample-workload
-  workload-billing-id: sample-id
-  workload-owner: sample-owner
-  workload-contact-info: sample-owner@sample.email
   # user or group to grant view role on workload namespace
   workload-view: 'group:client1@example.com'
   #


### PR DESCRIPTION
Landing zone v2 subpackage.
Depends on package `cluster-defaults`.
This package deploys to a GKE cluster.
It should be deployed once per workload namespace.

This package deploys a workload namespace and it's associated configuration.

---
Resources list:

- namespace
- resourcequota
- limitrange
- networkpolicies
- rolebinding for an application team
- a choice of Continuous Delivery(CD) solution which offer ConfigSync (Default) or ServiceAccount permission for external tools.

contributes to #479