### PR TITLE
fix: root-sync adding override

### DIFF
--- a/solutions/gke/kubernetes/namespace-defaults/cd/gitops-config-sync.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/cd/gitops-config-sync.yaml
@@ -21,6 +21,12 @@ metadata:
   namespace: config-management-system
 spec:
   sourceFormat: unstructured
+  override:
+    resources:
+      - containerName: "reconciler"
+        cpuLimit: "800m"
+        memoryLimit: "800Mi"
+        memoryRequest: "500Mi"
   git:
     repo: https://repo-url # kpt-set: ${repo-url}
     branch: main # kpt-set: ${repo-branch}


### PR DESCRIPTION
closes #496 

The Anthos Config Management feature is enabled on the cluster. There is a known issue with the root-sync resource when deployed to an autopilot cluster.
The reconciler container keeps crashing with an out-of-memory error message because it hits the memory limit.
To fix this, you need the override section in the `rootsync` resources.