### PR TITLE
fix: Resolve conflicting Client LZ Loadbalancer Policy

### DIFF
--- a/solutions/client-landing-zone/client-folder/standard/org-policies/exceptions/compute-restrict-load-balancer-creation-for-types.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/org-policies/exceptions/compute-restrict-load-balancer-creation-for-types.yaml
@@ -30,7 +30,7 @@
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: ResourceManagerPolicy
 metadata:
-  name: compute-restrict-load-balancer-creation-for-types-except-standard-folder # kpt-set: ${client-name}-restrict-load-balancer-creation-for-types-except-standard-folder
+  name: client-name-restrict-load-balancer-creation-for-types-except-standard-folder # kpt-set: ${client-name}-restrict-load-balancer-creation-for-types-except-standard-folder
   namespace: policies
   annotations:
     config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-hierarchy/Folder/standard # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-hierarchy/Folder/standard

--- a/solutions/client-landing-zone/client-folder/standard/org-policies/exceptions/compute-restrict-load-balancer-creation-for-types.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/org-policies/exceptions/compute-restrict-load-balancer-creation-for-types.yaml
@@ -30,7 +30,7 @@
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: ResourceManagerPolicy
 metadata:
-  name: compute-restrict-load-balancer-creation-for-types-except-standard-folder
+  name: compute-restrict-load-balancer-creation-for-types-except-standard-folder # kpt-set: ${client-name}-restrict-load-balancer-creation-for-types-except-standard-folder
   namespace: policies
   annotations:
     config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-hierarchy/Folder/standard # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-hierarchy/Folder/standard

--- a/solutions/client-landing-zone/client-folder/standard/org-policies/exceptions/compute-restrict-load-balancer-creation-for-types.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/org-policies/exceptions/compute-restrict-load-balancer-creation-for-types.yaml
@@ -30,7 +30,7 @@
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: ResourceManagerPolicy
 metadata:
-  name: client-name-restrict-load-balancer-creation-for-types-except-standard-folder # kpt-set: ${client-name}-restrict-load-balancer-creation-for-types-except-standard-folder
+  name: compute-restrict-load-balancer-creation-for-types-except-client-name-standard-folder # kpt-set: compute-restrict-load-balancer-creation-for-types-except-${client-name}-standard-folder
   namespace: policies
   annotations:
     config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-hierarchy/Folder/standard # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-hierarchy/Folder/standard


### PR DESCRIPTION
This PR aims to address issue #503 by adding the client name to the org policy to give it a unique value and prevent conflicts with other clients policies.