### PR TITLE
fix: error when creating MonitoringNotificationChannel as part of gke…

### DIFF
--- a/solutions/client-setup/README.md
+++ b/solutions/client-setup/README.md
@@ -15,8 +15,8 @@ Package to setup a client's namespaces, folder, management project and root sync
 |             Name             |              Value              | Type | Count |
 |------------------------------|---------------------------------|------|-------|
 | client-billing-id            | AAAAAA-BBBBBB-CCCCCC            | str  |     1 |
-| client-management-project-id | client-management-project-12345 | str  |   105 |
-| client-name                  | client1                         | str  |   124 |
+| client-management-project-id | client-management-project-12345 | str  |   107 |
+| client-name                  | client1                         | str  |   127 |
 | dns-project-id               | dns-project-12345               | str  |     1 |
 | environment                  | env                             | str  |     1 |
 | management-namespace         | config-control                  | str  |    25 |
@@ -54,6 +54,7 @@ This package has no sub-packages.
 | namespaces/client-name-hierarchy.yaml            | rbac.authorization.k8s.io/v1                  | RoleBinding            | allow-client-name-hierarchy-resource-reference-from-policies                           | client-name-hierarchy      |
 | namespaces/client-name-logging.yaml              | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount      | client-name-logging-sa                                                                 | client-name-config-control |
 | namespaces/client-name-logging.yaml              | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-logging-sa-logadmin-permissions                                            | hierarchy                  |
+| namespaces/client-name-logging.yaml              | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-logging-sa-monitoringadmin-permissions                                     | hierarchy                  |
 | namespaces/client-name-logging.yaml              | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-logging-sa-bigqueryadmin-permissions                                       | hierarchy                  |
 | namespaces/client-name-logging.yaml              | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | client-name-logging-sa-workload-identity-binding                                       | client-name-config-control |
 | namespaces/client-name-logging.yaml              | v1                                            | Namespace              | client-name-logging                                                                    |                            |

--- a/solutions/client-setup/namespaces/client-name-logging.yaml
+++ b/solutions/client-setup/namespaces/client-name-logging.yaml
@@ -42,6 +42,23 @@ spec:
   role: roles/logging.admin
   member: "serviceAccount:client-name-logging-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-logging-sa@${client-management-project-id}.iam.gserviceaccount.com
 ---
+# Grant GCP role Monitoring Admin to GCP SA
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: client-name-logging-sa-monitoringadmin-permissions # kpt-set: ${client-name}-logging-sa-monitoringadmin-permissions
+  namespace: hierarchy
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    name: clients.client-name # kpt-set: clients.${client-name}
+  role: roles/monitoring.admin
+  member: "serviceAccount:client-name-logging-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-logging-sa@${client-management-project-id}.iam.gserviceaccount.com
+---
 # Grant GCP role BigQuery Admin to GCP SA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember


### PR DESCRIPTION
adding monitoring admin role to logging service account to fix the error when creating MonitoringNotificationChannel as part of gke-setup

closes #506 