### PR TITLE
fix: gke-setup - using proper role id for gke firewall admin

### DIFF
--- a/solutions/gke/configconnector/gke-setup/host-project/project-iam.yaml
+++ b/solutions/gke/configconnector/gke-setup/host-project/project-iam.yaml
@@ -53,7 +53,7 @@ spec:
   role: roles/compute.networkUser
   member: "serviceAccount:service-project-number@container-engine-robot.iam.gserviceaccount.com" # kpt-set: serviceAccount:service-${project-number}@container-engine-robot.iam.gserviceaccount.com
 ---
-# Grant custom role: gkefirewall.admin on the host project to service-SERVICE_PROJECT_1_NUM@container-engine-robot.iam.gserviceaccount.com
+# Grant custom role: gke.firewall.admin on the host project to service-SERVICE_PROJECT_1_NUM@container-engine-robot.iam.gserviceaccount.com
 # If you want a GKE cluster in a service project to create and manage the firewall resources in your host project,
 # the service project's GKE service account must be granted the appropriate IAM permissions
 # https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#managing_firewall_resources
@@ -69,7 +69,7 @@ spec:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
     name: host-project-id # kpt-set: ${host-project-id}
-  role: organizations/org-id/roles/gkefirewall.admin # kpt-set: organizations/${org-id}/roles/gkefirewall.admin
+  role: organizations/org-id/roles/gke.firewall.admin # kpt-set: organizations/${org-id}/roles/gke.firewall.admin
   member: "serviceAccount:service-project-number@container-engine-robot.iam.gserviceaccount.com" # kpt-set: serviceAccount:service-${project-number}@container-engine-robot.iam.gserviceaccount.com
 ---
 # Grant custom role: Tier3 Subnetwork Admin on the host project to tier3 SA


### PR DESCRIPTION
using proper role id for gke firewall admin
closes #509
 