### PR TITLE
feat: add client admin ns and gke admin proxy

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -8,6 +8,7 @@
     "solutions/experimentation/client-project": "0.1.0",
     "solutions/experimentation/core-landing-zone": "0.1.0",
     "solutions/gatekeeper-policies": "0.2.0",
+    "solutions/gke/configconnector/gke-admin-proxy": "0.0.1",
     "solutions/gke/configconnector/gke-cluster-autopilot": "0.2.1",
     "solutions/gke/configconnector/gke-defaults": "0.2.0",
     "solutions/gke/configconnector/gke-setup": "0.2.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -52,6 +52,11 @@
       "tag-separator": "/",
       "prerelease": true
     },
+    "solutions/gke/configconnector/gke-admin-proxy": {
+      "package-name": "solutions/gke/configconnector/gke-admin-proxy",
+      "tag-separator": "/",
+      "prerelease": true
+    },
     "solutions/gke/configconnector/gke-cluster-autopilot": {
       "package-name": "solutions/gke/configconnector/gke-cluster-autopilot",
       "tag-separator": "/",

--- a/solutions/client-setup/README.md
+++ b/solutions/client-setup/README.md
@@ -15,12 +15,12 @@ Package to setup a client's namespaces, folder, management project and root sync
 |             Name             |              Value              | Type | Count |
 |------------------------------|---------------------------------|------|-------|
 | client-billing-id            | AAAAAA-BBBBBB-CCCCCC            | str  |     1 |
-| client-management-project-id | client-management-project-12345 | str  |   107 |
-| client-name                  | client1                         | str  |   127 |
+| client-management-project-id | client-management-project-12345 | str  |   119 |
+| client-name                  | client1                         | str  |   152 |
 | dns-project-id               | dns-project-12345               | str  |     1 |
 | environment                  | env                             | str  |     1 |
-| management-namespace         | config-control                  | str  |    25 |
-| management-project-id        | management-project-12345        | str  |     5 |
+| management-namespace         | config-control                  | str  |    27 |
+| management-project-id        | management-project-12345        | str  |     6 |
 | management-project-number    |                      0000000000 | str  |     1 |
 | org-id                       |                      0000000000 | str  |     3 |
 | repo-branch                  | main                            | str  |     1 |
@@ -44,6 +44,14 @@ This package has no sub-packages.
 | mgmt-project/services.yaml                       | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                | client-management-project-id-container                                                 | projects                   |
 | mgmt-project/services.yaml                       | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                | client-management-project-id-ids                                                       | projects                   |
 | mgmt-project/services.yaml                       | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                | client-management-project-id-servicenetworking                                         | projects                   |
+| namespaces/client-name-admin.yaml                | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount      | client-name-admin-sa                                                                   | client-name-config-control |
+| namespaces/client-name-admin.yaml                | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | client-name-admin-sa-workload-identity-binding                                         | client-name-config-control |
+| namespaces/client-name-admin.yaml                | v1                                            | Namespace              | client-name-admin                                                                      |                            |
+| namespaces/client-name-admin.yaml                | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com                                      | client-name-admin          |
+| namespaces/client-name-admin.yaml                | rbac.authorization.k8s.io/v1                  | RoleBinding            | allow-resource-reference-from-client-name-admin                                        | client-name-projects       |
+| namespaces/client-name-admin.yaml                | rbac.authorization.k8s.io/v1                  | RoleBinding            | allow-resource-reference-from-client-name-projects                                     | client-name-admin          |
+| namespaces/client-name-admin.yaml                | rbac.authorization.k8s.io/v1                  | RoleBinding            | allow-resource-reference-from-client-name-admin                                        | client-name-networking     |
+| namespaces/client-name-admin.yaml                | rbac.authorization.k8s.io/v1                  | RoleBinding            | allow-resource-reference-from-client-name-networking                                   | client-name-admin          |
 | namespaces/client-name-hierarchy.yaml            | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount      | client-name-hierarchy-sa                                                               | client-name-config-control |
 | namespaces/client-name-hierarchy.yaml            | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-hierarchy-sa-folderadmin-permissions                                       | hierarchy                  |
 | namespaces/client-name-hierarchy.yaml            | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | client-name-hierarchy-sa-workload-identity-binding                                     | client-name-config-control |
@@ -76,6 +84,7 @@ This package has no sub-packages.
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-xpnadmin-permissions                                         | config-control             |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-servicedirectoryeditor-permissions                           | hierarchy                  |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-client-folder-org-resource-admin-permissions                 | hierarchy                  |
+| namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-cloudids-admin-permissions                                   | hierarchy                  |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | client-name-networking-sa-workload-identity-binding                                    | client-name-config-control |
 | namespaces/client-name-networking.yaml           | v1                                            | Namespace              | client-name-networking                                                                 |                            |
 | namespaces/client-name-networking.yaml           | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com                                      | client-name-networking     |

--- a/solutions/client-setup/README.md
+++ b/solutions/client-setup/README.md
@@ -15,8 +15,8 @@ Package to setup a client's namespaces, folder, management project and root sync
 |             Name             |              Value              | Type | Count |
 |------------------------------|---------------------------------|------|-------|
 | client-billing-id            | AAAAAA-BBBBBB-CCCCCC            | str  |     1 |
-| client-management-project-id | client-management-project-12345 | str  |   119 |
-| client-name                  | client1                         | str  |   152 |
+| client-management-project-id | client-management-project-12345 | str  |   117 |
+| client-name                  | client1                         | str  |   149 |
 | dns-project-id               | dns-project-12345               | str  |     1 |
 | environment                  | env                             | str  |     1 |
 | management-namespace         | config-control                  | str  |    27 |
@@ -84,7 +84,6 @@ This package has no sub-packages.
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-xpnadmin-permissions                                         | config-control             |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-servicedirectoryeditor-permissions                           | hierarchy                  |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-client-folder-org-resource-admin-permissions                 | hierarchy                  |
-| namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-cloudids-admin-permissions                                   | hierarchy                  |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | client-name-networking-sa-workload-identity-binding                                    | client-name-config-control |
 | namespaces/client-name-networking.yaml           | v1                                            | Namespace              | client-name-networking                                                                 |                            |
 | namespaces/client-name-networking.yaml           | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com                                      | client-name-networking     |

--- a/solutions/client-setup/namespaces/client-name-admin.yaml
+++ b/solutions/client-setup/namespaces/client-name-admin.yaml
@@ -1,0 +1,138 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# GCP SA, has no permissions defined by default, they will be granted on a case by case basis to limit scope
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: client-name-admin-sa # kpt-set: ${client-name}-admin-sa
+  namespace: client-name-config-control # kpt-set: ${client-name}-${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/project-id: client-management-project-id # kpt-set: ${client-management-project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
+spec:
+  displayName: client-name-admin-sa # kpt-set: ${client-name}-admin-sa
+---
+# K8S SA
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata:
+  name: client-name-admin-sa-workload-identity-binding # kpt-set: ${client-name}-admin-sa-workload-identity-binding
+  namespace: client-name-config-control # kpt-set: ${client-name}-${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
+spec:
+  resourceRef:
+    name: client-name-admin-sa # kpt-set: ${client-name}-admin-sa
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-client-name-admin] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-${client-name}-admin]
+---
+# K8S namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: client-name-admin # kpt-set: ${client-name}-admin
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
+---
+# Link GCP SA to K8S namespace
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: client-name-admin # kpt-set: ${client-name}-admin
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
+spec:
+  googleServiceAccount: client-name-admin-sa@client-management-project-id.iam.gserviceaccount.com # kpt-set: ${client-name}-admin-sa@${client-management-project-id}.iam.gserviceaccount.com
+---
+# Grant viewer role on the client projects namespace to client admin K8S SA
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-resource-reference-from-client-name-admin # kpt-set: allow-resource-reference-from-${client-name}-admin
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
+roleRef:
+  name: cnrm-viewer
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: cnrm-controller-manager-client-name-admin # kpt-set: cnrm-controller-manager-${client-name}-admin
+    namespace: cnrm-system
+    kind: ServiceAccount
+---
+# Grant viewer role on the client admin namespace to client projects K8S SA
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-resource-reference-from-client-name-projects # kpt-set: allow-resource-reference-from-${client-name}-projects
+  namespace: client-name-admin # kpt-set: ${client-name}-admin
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
+roleRef:
+  name: cnrm-viewer
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: cnrm-controller-manager-client-name-projects # kpt-set: cnrm-controller-manager-${client-name}-projects
+    namespace: cnrm-system
+    kind: ServiceAccount
+---
+# Grant viewer role on the client networking namespace to client admin K8S SA
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-resource-reference-from-client-name-admin # kpt-set: allow-resource-reference-from-${client-name}-admin
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
+roleRef:
+  name: cnrm-viewer
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: cnrm-controller-manager-client-name-admin # kpt-set: cnrm-controller-manager-${client-name}-admin
+    namespace: cnrm-system
+    kind: ServiceAccount
+---
+# Grant viewer role on the client admin namespace to client networking K8S SA
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-resource-reference-from-client-name-networking # kpt-set: allow-resource-reference-from-${client-name}-networking
+  namespace: client-name-admin # kpt-set: ${client-name}-admin
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
+roleRef:
+  name: cnrm-viewer
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: cnrm-controller-manager-client-name-networking # kpt-set: cnrm-controller-manager-${client-name}-networking
+    namespace: cnrm-system
+    kind: ServiceAccount

--- a/solutions/client-setup/namespaces/client-name-networking.yaml
+++ b/solutions/client-setup/namespaces/client-name-networking.yaml
@@ -162,23 +162,6 @@ spec:
   role: roles/compute.orgSecurityResourceAdmin
   member: serviceAccount:client-name-networking-sa@client-management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:${client-name}-networking-sa@${client-management-project-id}.iam.gserviceaccount.com
 ---
-# Grant GCP role Cloud IDS Admin to GCP SA
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
-metadata:
-  name: client-name-networking-sa-cloudids-admin-permissions # kpt-set: ${client-name}-networking-sa-cloudids-admin-permissions
-  namespace: hierarchy
-  annotations:
-    cnrm.cloud.google.com/ignore-clusterless: "true"
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
-spec:
-  resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Folder
-    name: clients.client-name # kpt-set: clients.${client-name}
-  role: roles/ids.admin
-  member: "serviceAccount:client-name-networking-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-networking-sa@${client-management-project-id}.iam.gserviceaccount.com
----
 # K8S SA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy

--- a/solutions/client-setup/namespaces/client-name-networking.yaml
+++ b/solutions/client-setup/namespaces/client-name-networking.yaml
@@ -162,6 +162,23 @@ spec:
   role: roles/compute.orgSecurityResourceAdmin
   member: serviceAccount:client-name-networking-sa@client-management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:${client-name}-networking-sa@${client-management-project-id}.iam.gserviceaccount.com
 ---
+# Grant GCP role Cloud IDS Admin to GCP SA
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: client-name-networking-sa-cloudids-admin-permissions # kpt-set: ${client-name}-networking-sa-cloudids-admin-permissions
+  namespace: hierarchy
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    name: clients.client-name # kpt-set: clients.${client-name}
+  role: roles/ids.admin
+  member: "serviceAccount:client-name-networking-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-networking-sa@${client-management-project-id}.iam.gserviceaccount.com
+---
 # K8S SA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy

--- a/solutions/client-setup/setters.yaml
+++ b/solutions/client-setup/setters.yaml
@@ -58,9 +58,10 @@ data:
   #
   # Name for the client, lowercase only
   client-name: 'client1'
-  # Billing Account ID to be associated with this project
+  # Billing Account ID to associate with the client's managment project, the projects-sa will need billing user permission
+  # alternatively, it can be set to the core landing zone billing id, the client management project contains very limited resources
   client-billing-id: "AAAAAA-BBBBBB-CCCCCC"
-  # project id for the client management project, following rules and conventions
+  # project id for the client management project to be created, following rules and conventions
   client-management-project-id: client-management-project-12345
   #
   ##########################
@@ -82,8 +83,10 @@ data:
   ##########################
   # DNS
   ##########################
+  #
   # dns project id created in core-landing-zone
   dns-project-id: dns-project-12345
+  #
   ##########################
   # End of Configurations
   ##########################

--- a/solutions/gke/configconnector/gke-admin-proxy/Kptfile
+++ b/solutions/gke/configconnector/gke-admin-proxy/Kptfile
@@ -1,0 +1,17 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: gke-admin-proxy
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    Landing zone v2 optional package to deploy a compute engine instance in a given project for managing a private GKE cluster.
+
+    Depends on `client-setup`, uses the client namespaces.
+
+    Refer to the [documentation](https://cloud.google.com/kubernetes-engine/docs/tutorials/private-cluster-bastion) for more details.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/gke/configconnector/gke-admin-proxy/README.md
+++ b/solutions/gke/configconnector/gke-admin-proxy/README.md
@@ -1,0 +1,90 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# gke-admin-proxy
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+
+
+
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+Landing zone v2 optional package to deploy a compute engine instance in a given project for managing a private GKE cluster.
+
+Depends on `client-setup`, uses the client namespaces.
+
+Refer to the [documentation](https://cloud.google.com/kubernetes-engine/docs/tutorials/private-cluster-bastion) for more details.
+
+## Setters
+
+|             Name             |              Value              | Type | Count |
+|------------------------------|---------------------------------|------|-------|
+| client-management-project-id | client-management-project-12345 | str  |     3 |
+| client-name                  | client1                         | str  |    37 |
+| gke-admins                   | group:my-admins@example.com     | str  |     4 |
+| host-project-id              | host-project-id                 | str  |     2 |
+| instance-ip                  | instance-ip                     | str  |     1 |
+| instance-machine-type        | instance-machine-type           | str  |     1 |
+| instance-name                | instance-name                   | str  |    21 |
+| instance-os-image            | instance-os-image               | str  |     1 |
+| location                     | location                        | str  |     2 |
+| network-name                 | network-name                    | str  |     2 |
+| project-id                   | project-id-12345                | str  |    38 |
+| subnet-name                  | subnet-name                     | str  |     2 |
+
+## Sub-packages
+
+- [instance-resources](instance-resources)
+
+## Resources
+
+|       File       |            APIVersion             |      Kind       |                                Name                                |      Namespace       |
+|------------------|-----------------------------------|-----------------|--------------------------------------------------------------------|----------------------|
+| project-iam.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | project-id-client-name-admin-sa-service-account-admin-permissions  | client-name-projects |
+| project-iam.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | project-id-client-name-admin-sa-compute-instance-admin-permissions | client-name-projects |
+| project-iam.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | project-id-client-name-admin-sa-service-account-user-permissions   | client-name-projects |
+| project-iam.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | project-id-iap-tunnel-user                                         | client-name-projects |
+| project-iam.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | project-id-gke-admins-viewer                                       | client-name-projects |
+
+## Resource References
+
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/gke/configconnector/gke-admin-proxy@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd "./gke-admin-proxy/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/gke/configconnector/gke-admin-proxy/instance-resources/Kptfile
+++ b/solutions/gke/configconnector/gke-admin-proxy/instance-resources/Kptfile
@@ -1,0 +1,20 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: instance-resources
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: |
+    gke-admin-proxy sub-package to deploy the instance resources.
+
+    Depends on setters from its parent package.
+
+    ***Note:*** Some resources use a double dash (`--`) to separate setters value, to work around a known behavior described [here](https://github.com/GoogleContainerTools/kpt/issues/3330).
+
+    Multiple copies of this subpackage can exist by copying the entire folder to a new folder (i.e. subpackage2).
+    This may be required to manage GKE clusters located in different subnets/regions.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/solutions/gke/configconnector/gke-admin-proxy/instance-resources/README.md
+++ b/solutions/gke/configconnector/gke-admin-proxy/instance-resources/README.md
@@ -1,0 +1,97 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# instance-resources
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+
+
+
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+gke-admin-proxy sub-package to deploy the instance resources.
+
+Depends on setters from its parent package.
+
+***Note:*** Some resources use a double dash (`--`) to separate setters value, to work around a known behavior described [here](https://github.com/GoogleContainerTools/kpt/issues/3330).
+
+Multiple copies of this subpackage can exist by copying the entire folder to a new folder (i.e. subpackage2).
+This may be required to manage GKE clusters located in different subnets/regions.
+
+## Setters
+
+|         Name          |                Value                | Type | Count |
+|-----------------------|-------------------------------------|------|-------|
+| client-name           | client-name                         | str  |    21 |
+| gke-admins            | gke-admins                          | str  |     2 |
+| host-project-id       | net-host-project-12345              | str  |     2 |
+| instance-ip           | 1.2.3.4                             | str  |     1 |
+| instance-machine-type | e2-small                            | str  |     1 |
+| instance-name         | proxy1                              | str  |    21 |
+| instance-os-image     | a-project-with-images/the-image     | str  |     1 |
+| location              | northamerica-northeast1             | str  |     2 |
+| network-name          | host-project-id-global-standard-vpc | str  |     2 |
+| project-id            | project-id                          | str  |    23 |
+| subnet-name           | host-project-id-subnet-name         | str  |     2 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|       File        |              APIVersion               |       Kind        |                         Name                          |       Namespace        |
+|-------------------|---------------------------------------|-------------------|-------------------------------------------------------|------------------------|
+| address.yaml      | compute.cnrm.cloud.google.com/v1beta1 | ComputeAddress    | project-id--instance-name-ip                          | client-name-networking |
+| firewall-iap.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeFirewall   | project-id--instance-name-sa-iap-ssh-fwr              | client-name-networking |
+| iam.yaml          | iam.cnrm.cloud.google.com/v1beta1     | IAMServiceAccount | project-id--instance-name-sa                          | client-name-admin      |
+| iam.yaml          | iam.cnrm.cloud.google.com/v1beta1     | IAMPolicyMember   | project-id--instance-name-sa-iap-service-account-user | client-name-projects   |
+| iam.yaml          | iam.cnrm.cloud.google.com/v1beta1     | IAMPolicyMember   | project-id--instance-name-iap-compute-admin           | client-name-projects   |
+| instance.yaml     | compute.cnrm.cloud.google.com/v1beta1 | ComputeInstance   | project-id--instance-name                             | client-name-admin      |
+
+## Resource References
+
+- [ComputeAddress](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeaddress)
+- [ComputeFirewall](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computefirewall)
+- [ComputeInstance](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeinstance)
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [IAMServiceAccount](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/gke/configconnector/instance-resources@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd "./instance-resources/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/solutions/gke/configconnector/gke-admin-proxy/instance-resources/address.yaml
+++ b/solutions/gke/configconnector/gke-admin-proxy/instance-resources/address.yaml
@@ -1,0 +1,33 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# reserve an internal IP address for the instance
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
+metadata:
+  name: project-id--instance-name-ip # kpt-set: ${project-id}--${instance-name}-ip
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceID: project-id--instance-name-ip # kpt-set: ${project-id}--${instance-name}-ip
+  description: internal IP for instance instance-name in project project-id # kpt-set: internal IP for instance ${instance-name} in project ${project-id}
+  address: instance-ip # kpt-set: ${instance-ip}
+  addressType: INTERNAL
+  location: location # kpt-set: ${location}
+  purpose: GCE_ENDPOINT
+  subnetworkRef:
+    name: subnet-name # kpt-set: ${subnet-name}
+    namespace: client-name-networking # kpt-set: ${client-name}-networking

--- a/solutions/gke/configconnector/gke-admin-proxy/instance-resources/firewall-iap.yaml
+++ b/solutions/gke/configconnector/gke-admin-proxy/instance-resources/firewall-iap.yaml
@@ -1,0 +1,37 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# IAP to GCE instance service account
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeFirewall
+metadata:
+  name: project-id--instance-name-sa-iap-ssh-fwr # kpt-set: ${project-id}--${instance-name}-sa-iap-ssh-fwr
+  namespace: client-name-networking # kpt-set: ${client-name}-networking
+  annotations:
+    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/client-name-admin/IAMServiceAccount/project-id--instance-name-sa # kpt-set: iam.cnrm.cloud.google.com/namespaces/${client-name}-admin/IAMServiceAccount/${project-id}--${instance-name}-sa
+spec:
+  resourceID: project-id--instance-name-sa-iap-ssh-fwr # kpt-set: ${project-id}--${instance-name}-sa-iap-ssh-fwr
+  allow:
+    - protocol: tcp
+      ports:
+        - "22"
+  networkRef:
+    name: network-name # kpt-set: ${network-name}
+    namespace: client-name-networking # kpt-set: ${client-name}-networking
+  sourceRanges:
+    - "35.235.240.0/20"
+  targetServiceAccounts:
+    - name: project-id--instance-name-sa # kpt-set: ${project-id}--${instance-name}-sa
+      namespace: client-name-admin # kpt-set: ${client-name}-admin

--- a/solutions/gke/configconnector/gke-admin-proxy/instance-resources/iam.yaml
+++ b/solutions/gke/configconnector/gke-admin-proxy/instance-resources/iam.yaml
@@ -1,0 +1,63 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Create the Service Account for the compute engine instance
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: project-id--instance-name-sa # kpt-set: ${project-id}--${instance-name}-sa
+  namespace: client-name-admin # kpt-set: ${client-name}-admin
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/client-name-projects/IAMPolicyMember/project-id-client-name-admin-sa-service-account-admin-permissions # kpt-set: iam.cnrm.cloud.google.com/namespaces/${client-name}-projects/IAMPolicyMember/${project-id}-${client-name}-admin-sa-service-account-admin-permissions
+spec:
+  resourceID: instance-name-sa # kpt-set: ${instance-name}-sa
+  displayName: Service Account to instance instance-name # kpt-set: Service Account to instance ${instance-name}
+---
+# Add all the required roles for IAP administration
+# https://cloud.google.com/iap/docs/using-tcp-forwarding#grant-permission
+# grant Service Account User to gke-admins on the instance's service account
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id--instance-name-sa-iap-service-account-user # kpt-set: ${project-id}--${instance-name}-sa-iap-service-account-user
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/client-name-admin/IAMServiceAccount/project-id--instance-name-sa # kpt-set: iam.cnrm.cloud.google.com/namespaces/${client-name}-admin/IAMServiceAccount/${project-id}--${instance-name}-sa
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: project-id--instance-name-sa # kpt-set: ${project-id}--${instance-name}-sa
+    namespace: client-name-admin # kpt-set: ${client-name}-admin
+  role: roles/iam.serviceAccountUser
+  member: gke-admins # kpt-set: ${gke-admins}
+---
+# grant Compute Instance Admin to gke-admins on the instance
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id--instance-name-iap-compute-admin # kpt-set: ${project-id}--${instance-name}-iap-compute-admin
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-admin/ComputeInstance/project-id--instance-name # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-admin/ComputeInstance/${project-id}--${instance-name}
+spec:
+  resourceRef:
+    apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    kind: ComputeInstance
+    name: project-id--instance-name # kpt-set: ${project-id}--${instance-name}
+    namespace: client-name-admin # kpt-set: ${client-name}-admin
+  role: roles/compute.instanceAdmin.v1
+  member: gke-admins # kpt-set: ${gke-admins}

--- a/solutions/gke/configconnector/gke-admin-proxy/instance-resources/instance.yaml
+++ b/solutions/gke/configconnector/gke-admin-proxy/instance-resources/instance.yaml
@@ -1,0 +1,79 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Create a compute instance to manage private GKE clusters
+# https://cloud.google.com/kubernetes-engine/docs/tutorials/private-cluster-bastion
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeInstance
+metadata:
+  name: project-id--instance-name # kpt-set: ${project-id}--${instance-name}
+  namespace: client-name-admin # kpt-set: ${client-name}-admin
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    cnrm.cloud.google.com/allow-stopping-for-update: "true"
+    cnrm.cloud.google.com/state-into-spec: "absent"
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/client-name-admin/IAMServiceAccount/project-id--instance-name-sa # kpt-set: iam.cnrm.cloud.google.com/namespaces/${client-name}-admin/IAMServiceAccount/${project-id}--${instance-name}-sa
+spec:
+  resourceID: instance-name # kpt-set: ${instance-name}
+  description: Instance to manage private GKE
+  machineType: instance-machine-type # kpt-set: ${instance-machine-type}
+  zone: location-a # kpt-set: ${location}-a
+  bootDisk:
+    autoDelete: true
+    deviceName: persistent-disk-0
+    initializeParams:
+      size: 20
+      type: pd-balanced
+      sourceImageRef:
+        external: instance-os-image # kpt-set: ${instance-os-image}
+  networkInterface:
+    - name: nic0
+      networkIpRef:
+        kind: ComputeAddress
+        name: project-id--instance-name-ip # kpt-set: ${project-id}--${instance-name}-ip
+        namespace: client-name-networking # kpt-set: ${client-name}-networking
+      networkRef:
+        name: network-name # kpt-set: ${network-name}
+        namespace: client-name-networking # kpt-set: ${client-name}-networking
+      stackType: IPV4_ONLY
+      subnetworkRef:
+        name: subnet-name # kpt-set: ${subnet-name}
+        namespace: client-name-networking # kpt-set: ${client-name}-networking
+      subnetworkProject: host-project-id # kpt-set: ${host-project-id}
+  serviceAccount:
+    serviceAccountRef:
+      name: project-id--instance-name-sa # kpt-set: ${project-id}--${instance-name}-sa
+      namespace: client-name-admin # kpt-set: ${client-name}-admin
+    scopes:
+      - https://www.googleapis.com/auth/cloud-platform
+  metadata:
+    - key: enable-oslogin
+      value: "TRUE"
+    - key: startup-script
+      value: |
+        #! /bin/bash
+        apt update
+        apt -y install tinyproxy
+        # add 'Allow localhost' entry after 'Allow 127.0.0.1' if it doesn't exist
+        grep --quiet '^Allow localhost$' /etc/tinyproxy/tinyproxy.conf \
+          || sed -i 's/Allow 127.0.0.1/Allow 127.0.0.1\nAllow localhost/g' /etc/tinyproxy/tinyproxy.conf
+        service tinyproxy restart
+  scheduling:
+    automaticRestart: true
+    onHostMaintenance: MIGRATE
+    provisioningModel: STANDARD
+  shieldedInstanceConfig:
+    enableIntegrityMonitoring: true
+    enableSecureBoot: true
+    enableVtpm: true

--- a/solutions/gke/configconnector/gke-admin-proxy/instance-resources/setters.yaml
+++ b/solutions/gke/configconnector/gke-admin-proxy/instance-resources/setters.yaml
@@ -1,0 +1,57 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  # setters from its parent package are also used.
+  #
+  ##########################
+  # Host Configurations
+  ##########################
+  #
+  # The region that the resources will be created in
+  location: northamerica-northeast1
+  #
+  # the name of the instance, limit 27 characters max
+  instance-name: proxy1
+  # the instance's machine type
+  instance-machine-type: e2-small
+  # the OS image to use, depending on the image, other changes may be required to:
+  #   - the startup-script in instance.yaml
+  #   - the `constraints/compute.trustedImageProjects` Organization Policy
+  #   - firewall policy rules to allow OS updates
+  instance-os-image: a-project-with-images/the-image
+  #
+  # ID of existing Shared VPC host project for the client created in the client-landing-zone package
+  host-project-id: net-host-project-12345
+  # the network and subnet to attach the instance's NIC, the values must match the kubernetes resources 'metadata.name'
+  network-name: host-project-id-global-standard-vpc
+  subnet-name: host-project-id-subnet-name
+  #
+  # the internal IP to reserve for the instance, must be unique within the CIDR range of the subnet above
+  instance-ip: 1.2.3.4
+  #
+  ##########################
+  # End of Configurations
+  ##########################

--- a/solutions/gke/configconnector/gke-admin-proxy/project-iam.yaml
+++ b/solutions/gke/configconnector/gke-admin-proxy/project-iam.yaml
@@ -1,0 +1,102 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+# Grant roles to client-name-admin-sa to manage required resources in this project
+# Grant GCP role Service Account Admin to GCP SA to manage service accounts
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-client-name-admin-sa-service-account-admin-permissions # kpt-set: ${project-id}-${client-name}-admin-sa-service-account-admin-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: project-id # kpt-set: ${project-id}
+  role: roles/iam.serviceAccountAdmin
+  member: "serviceAccount:client-name-admin-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-admin-sa@${client-management-project-id}.iam.gserviceaccount.com
+---
+# Grant GCP role Compute Instance Admin to GCP SA to manage compute instances
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-client-name-admin-sa-compute-instance-admin-permissions # kpt-set: ${project-id}-${client-name}-admin-sa-compute-instance-admin-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: project-id # kpt-set: ${project-id}
+  role: roles/compute.instanceAdmin.v1
+  member: "serviceAccount:client-name-admin-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-admin-sa@${client-management-project-id}.iam.gserviceaccount.com
+---
+# Grant GCP role Service Account User to GCP SA to run instances with service accounts
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-client-name-admin-sa-service-account-user-permissions # kpt-set: ${project-id}-${client-name}-admin-sa-service-account-user-permissions
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: project-id # kpt-set: ${project-id}
+  role: roles/iam.serviceAccountUser
+  member: "serviceAccount:client-name-admin-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-admin-sa@${client-management-project-id}.iam.gserviceaccount.com
+---
+# Add required roles for IAP administration
+# https://cloud.google.com/iap/docs/using-tcp-forwarding#grant-permission
+# grant Tunnel User role to gke-admins on the project
+# moving this on the instance requires IAP service enabled and currently doesn't appear possible to grant with config connector
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-iap-tunnel-user # kpt-set: ${project-id}-iap-tunnel-user
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: project-id # kpt-set: ${project-id}
+  role: roles/iap.tunnelResourceAccessor
+  member: gke-admins # kpt-set: ${gke-admins}
+---
+# grant Viewer role to gke-admins on the project
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-id-gke-admins-viewer # kpt-set: ${project-id}-gke-admins-viewer
+  namespace: client-name-projects # kpt-set: ${client-name}-projects
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: project-id # kpt-set: ${project-id}
+  role: roles/viewer
+  member: gke-admins # kpt-set: ${gke-admins}

--- a/solutions/gke/configconnector/gke-admin-proxy/securitycontrols.md
+++ b/solutions/gke/configconnector/gke-admin-proxy/securitycontrols.md
@@ -1,0 +1,7 @@
+# Security Controls
+
+<!-- BEGINNING OF SECURITY CONTROLS LIST -->
+|Security Control|File Name|Resource Name|
+|---|---|---|
+
+<!-- END OF SECURITY CONTROLS LIST -->

--- a/solutions/gke/configconnector/gke-admin-proxy/setters.yaml
+++ b/solutions/gke/configconnector/gke-admin-proxy/setters.yaml
@@ -1,0 +1,48 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ##########################
+  # Instructions
+  ##########################
+  #
+  # Follow instructions specific to each section.
+  #
+  ##########################
+  # Client
+  ##########################
+  #
+  # Name for the client, lowercase only
+  client-name: 'client1'
+  # id of the client management project created in the client-setup package
+  client-management-project-id: client-management-project-12345
+  #
+  ##########################
+  # Project
+  ##########################
+  #
+  # project id where the compute engine instance(s) will be deployed
+  project-id: project-id-12345
+  # the group of users to grant permissions to log in the instance(s)
+  gke-admins: 'group:my-admins@example.com'
+  #
+  ##########################
+  # End of Configurations
+  ##########################


### PR DESCRIPTION
supports #479

- `/solutions/client-setup`
    - add new client admin namespace for adhoc administrative tasks.

- `/solutions/gke/configconnector/gke-admin-proxy`
    - new package to assist in the administration of a private GKE cluster
