### PR TITLE
fix: enable missing logging for fw rules

### DIFF
--- a/examples/landing-zone-v2/configconnector/tier3/external-load-balancer/firewall.yaml
+++ b/examples/landing-zone-v2/configconnector/tier3/external-load-balancer/firewall.yaml
@@ -34,3 +34,5 @@ spec:
   targetServiceAccounts:
     - name: workload-name-sa # kpt-set: ${workload-name}-sa
       namespace: project-id-tier4 # kpt-set: ${project-id}-tier4
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"

--- a/examples/landing-zone-v2/configconnector/tier3/firewall-policy-rules/allow-egress-fqdns.yaml
+++ b/examples/landing-zone-v2/configconnector/tier3/firewall-policy-rules/allow-egress-fqdns.yaml
@@ -23,7 +23,7 @@ spec:
   description: "allow access to example.com"
   direction: "EGRESS"
   disabled: false
-  enableLogging: false
+  enableLogging: true
   firewallPolicyRef:
     name: client-name-standard-applications-infrastructure-fwpol # kpt-set: ${client-name}-standard-applications-infrastructure-fwpol
     namespace: client-name-networking # kpt-set: ${client-name}-networking

--- a/examples/landing-zone-v2/configconnector/tier3/remote-access-to-gce/firewall-iap.yaml
+++ b/examples/landing-zone-v2/configconnector/tier3/remote-access-to-gce/firewall-iap.yaml
@@ -34,3 +34,5 @@ spec:
   targetServiceAccounts:
     - name: workload-name-sa # kpt-set: ${workload-name}-sa
       namespace: project-id-tier4 # kpt-set: ${project-id}-tier4
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"

--- a/solutions/client-landing-zone/client-folder/firewall-policy/rules/defaults.yaml
+++ b/solutions/client-landing-zone/client-folder/firewall-policy/rules/defaults.yaml
@@ -27,6 +27,7 @@ spec:
   description: "Exclude communication with private IP ranges, leaving only Internet traffic to be inspected (EGRESS)"
   direction: "EGRESS"
   disabled: false
+  # logging not supported for goto_next rules
   enableLogging: false
   firewallPolicyRef:
     name: client-name-client-folder-fwpol # kpt-set: ${client-name}-client-folder-fwpol
@@ -53,6 +54,7 @@ spec:
   description: "Exclude communication with private IP ranges, leaving only Internet traffic to be inspected (INGRESS)"
   direction: "INGRESS"
   disabled: false
+  # logging not supported for goto_next rules
   enableLogging: false
   firewallPolicyRef:
     name: client-name-client-folder-fwpol # kpt-set: ${client-name}-client-folder-fwpol

--- a/solutions/client-landing-zone/client-folder/firewall-policy/rules/iap.yaml
+++ b/solutions/client-landing-zone/client-folder/firewall-policy/rules/iap.yaml
@@ -25,6 +25,7 @@ spec:
   description: "Goto next for IAP"
   direction: "INGRESS"
   disabled: false
+  # logging not supported for goto_next rules
   enableLogging: false
   firewallPolicyRef:
     name: client-name-client-folder-fwpol # kpt-set: ${client-name}-client-folder-fwpol

--- a/solutions/client-landing-zone/client-folder/firewall-policy/rules/lb-health-checks.yaml
+++ b/solutions/client-landing-zone/client-folder/firewall-policy/rules/lb-health-checks.yaml
@@ -25,6 +25,7 @@ spec:
   description: "Goto next for LB health checks"
   direction: "INGRESS"
   disabled: false
+  # logging not supported for goto_next rules
   enableLogging: false
   firewallPolicyRef:
     name: client-name-client-folder-fwpol # kpt-set: ${client-name}-client-folder-fwpol

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/firewall-policy/rules/defaults.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/firewall-policy/rules/defaults.yaml
@@ -27,6 +27,7 @@ spec:
   description: "Exclude communication with private IP ranges, leaving only Internet traffic to be inspected (EGRESS)"
   direction: "EGRESS"
   disabled: false
+  # logging not supported for goto_next rules
   enableLogging: false
   firewallPolicyRef:
     name: client-name-standard-applications-infrastructure-fwpol # kpt-set: ${client-name}-standard-applications-infrastructure-fwpol
@@ -53,6 +54,7 @@ spec:
   description: "Exclude communication with private IP ranges, leaving only Internet traffic to be inspected (INGRESS)"
   direction: "INGRESS"
   disabled: false
+  # logging not supported for goto_next rules
   enableLogging: false
   firewallPolicyRef:
     name: client-name-standard-applications-infrastructure-fwpol # kpt-set: ${client-name}-standard-applications-infrastructure-fwpol

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/firewall-policy/rules/iap.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/firewall-policy/rules/iap.yaml
@@ -25,6 +25,7 @@ spec:
   description: "Goto next for IAP"
   direction: "INGRESS"
   disabled: false
+  # logging not supported for goto_next rules
   enableLogging: false
   firewallPolicyRef:
     name: client-name-standard-applications-infrastructure-fwpol # kpt-set: ${client-name}-standard-applications-infrastructure-fwpol

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/firewall-policy/rules/lb-health-checks.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/firewall-policy/rules/lb-health-checks.yaml
@@ -25,6 +25,7 @@ spec:
   description: "Goto next for LB health checks"
   direction: "INGRESS"
   disabled: false
+  # logging not supported for goto_next rules
   enableLogging: false
   firewallPolicyRef:
     name: client-name-standard-applications-infrastructure-fwpol # kpt-set: ${client-name}-standard-applications-infrastructure-fwpol

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/firewall.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/firewall.yaml
@@ -35,6 +35,8 @@ spec:
     - "192.168.0.0/16"
   networkRef:
     name: host-project-id-global-standard-vpc # kpt-set: ${host-project-id}-global-standard-vpc
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"
 ---
 # Default egress deny all
 # AC-4, AC-4(21), SC-7(C), SC-7(5)

--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/firewall.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/psc/google-apis/firewall.yaml
@@ -33,3 +33,5 @@ spec:
     - 10.255.255.254/32
   networkRef:
     name: host-project-id-global-standard-vpc # kpt-set: ${host-project-id}-global-standard-vpc
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"

--- a/solutions/gke/configconnector/gke-admin-proxy/instance-resources/firewall-iap.yaml
+++ b/solutions/gke/configconnector/gke-admin-proxy/instance-resources/firewall-iap.yaml
@@ -35,3 +35,5 @@ spec:
   targetServiceAccounts:
     - name: project-id--instance-name-sa # kpt-set: ${project-id}--${instance-name}-sa
       namespace: client-name-admin # kpt-set: ${client-name}-admin
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"

--- a/solutions/gke/configconnector/gke-cluster-autopilot/host-project/firewall.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/host-project/firewall.yaml
@@ -31,3 +31,5 @@ spec:
     - "130.211.0.0/22"
   destinationRanges: # kpt-set: ${podIpv4Range}
     - podIpv4Range
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"

--- a/solutions/project/hub-env/fortigate/firewall.yaml
+++ b/solutions/project/hub-env/fortigate/firewall.yaml
@@ -31,6 +31,8 @@ spec:
     name: hub-global-external-vpc
   sourceRanges:
     - 0.0.0.0/0
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"
 ---
 ## External Load Balancers health checks
 ## https://cloud.google.com/load-balancing/docs/health-checks#fw-rule
@@ -56,6 +58,8 @@ spec:
     - "130.211.0.0/22"
   targetServiceAccounts:
     - name: hub-fortigatesdn-sa
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"
 ---
 ## Internal allow spokes to fortigates
 ## AC-3(7) use of SA account with limited permissions
@@ -79,6 +83,8 @@ spec:
     - 10.0.0.0/8
   targetServiceAccounts:
     - name: hub-fortigatesdn-sa
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"
 ---
 ## Internal Load Balancers health checks
 ## https://cloud.google.com/load-balancing/docs/health-checks#fw-rule
@@ -104,6 +110,8 @@ spec:
     - "130.211.0.0/22"
   targetServiceAccounts:
     - name: hub-fortigatesdn-sa
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"
 ---
 ## Enable traffic on mgmt network for fortigates HA
 ## AC-3(7) use of SA account with limited permissions
@@ -126,3 +134,5 @@ spec:
     - name: hub-fortigatesdn-sa
   targetServiceAccounts:
     - name: hub-fortigatesdn-sa
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"

--- a/solutions/project/hub-env/fortigate/management-vm/firewall.yaml
+++ b/solutions/project/hub-env/fortigate/management-vm/firewall.yaml
@@ -37,6 +37,8 @@ spec:
     - "35.235.240.0/20"
   targetServiceAccounts:
     - name: hub-managementvm-sa
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"
 ---
 ## Management VM to Fortigates - ICMP and TCP SSH, HTTPS
 ## AC-17(1) - Users are forced to use IAP Desktop to access (via RDP) the management Google Compute Engine in order to access and manage the Fortigate appliance through SSH or HTTPS.
@@ -65,3 +67,5 @@ spec:
     - name: hub-managementvm-sa
   targetServiceAccounts:
     - name: hub-fortigatesdn-sa
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"

--- a/solutions/project/hub-env/samples/Egress-workload-to-common-services.md
+++ b/solutions/project/hub-env/samples/Egress-workload-to-common-services.md
@@ -67,4 +67,6 @@
       - "10.1.1.2/32"
       targetServiceAccounts:
       - name: project-id-service1-sa # kpt-set: ${project-id}-service1-sa
+      logConfig:
+        metadata: "INCLUDE_ALL_METADATA"
     ```

--- a/solutions/project/hub-env/samples/Ingress-internet-to workload.md
+++ b/solutions/project/hub-env/samples/Ingress-internet-to workload.md
@@ -149,4 +149,6 @@
       - "0.0.0.0/0"
       targetServiceAccounts:
       - name: project-id-workload1-sa # kpt-set: ${project-id}-workload1-sa
+      logConfig:
+        metadata: "INCLUDE_ALL_METADATA"
     ```

--- a/solutions/project/spoke-unclass-env/network/psc/google-apis/firewall.yaml
+++ b/solutions/project/spoke-unclass-env/network/psc/google-apis/firewall.yaml
@@ -33,6 +33,8 @@ spec:
     - 10.255.255.254/32
   networkRef:
     name: project-id-global-vpc1-vpc # kpt-set: ${project-id}-global-vpc1-vpc
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"
 ---
 # Default egress deny all
 # AC-4, AC-4(21), SC-7(C), SC-7(5)
@@ -60,3 +62,5 @@ spec:
     - 10.2.3.0/24
   networkRef:
     name: project-id-global-vpc1-vpc # kpt-set: ${project-id}-global-vpc1-vpc
+  logConfig:
+    metadata: "INCLUDE_ALL_METADATA"


### PR DESCRIPTION
closes #523 

enable logging on firewall rules that had it disabled