### PR TITLE
#540 - adjust LZ README.md add json release URL for KPT instructions

### DIFF
--- a/docs/landing-zone-v2/README.md
+++ b/docs/landing-zone-v2/README.md
@@ -400,29 +400,32 @@ cd pbmm-landingzone
 
     ```shell
     PACKAGE="solutions/gatekeeper-policies"
-    VERSION=$(curl -s $URL | jq -r ".\"$PACKAGE\"")
+    #VERSION=$(curl -s $URL | jq -r ".\"$PACKAGE\"")
+    VERSION=main
     kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/${PACKAGE}@${VERSION}
     ```
 
    All Gatekeeper Policy Package releases can be found [here](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/releases?q=gatekeeper&expanded=true)
 
-2. Get the landing zone package
+2. Get the core landing zone package 
 
     - Experimentation
 
       ```shell
       PACKAGE="solutions/experimentation/core-landing-zone"
-      VERSION=$(curl -s $URL | jq -r ".\"$PACKAGE\"")
+      #VERSION=$(curl -s $URL | jq -r ".\"$PACKAGE\"")
+      VERSION=main
       kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/${PACKAGE}@${VERSION}
       ```
 
       [Releases List](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/releases?q=experimentation&expanded=true)
 
-    - DEV, PREPROD, PROD
+    - or DEV, PREPROD, PROD
 
       ```shell
       PACKAGE="solutions/core-landing-zone"
-      VERSION=$(curl -s $URL | jq -r ".\"$PACKAGE\"")
+      #VERSION=$(curl -s $URL | jq -r ".\"$PACKAGE\"")
+      VERSION=main
       kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/${PACKAGE}@${VERSION}
       ```
 

--- a/docs/landing-zone-v2/README.md
+++ b/docs/landing-zone-v2/README.md
@@ -407,7 +407,7 @@ cd pbmm-landingzone
 
    All Gatekeeper Policy Package releases can be found [here](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/releases?q=gatekeeper&expanded=true)
 
-2. Get the core landing zone package 
+2. Get the core landing zone package
 
     - Experimentation
 

--- a/docs/landing-zone-v2/README.md
+++ b/docs/landing-zone-v2/README.md
@@ -399,9 +399,9 @@ cd pbmm-landingzone
    The latest versions of the releases can be found in [Releases](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/releases). The provided versions are examples and may not be up to date.
 
     ```shell
+    URL="https://raw.githubusercontent.com/GoogleCloudPlatform/pubsec-declarative-toolkit/main/.release-please-manifest.json"
     PACKAGE="solutions/gatekeeper-policies"
-    #VERSION=$(curl -s $URL | jq -r ".\"$PACKAGE\"")
-    VERSION=main
+    VERSION=$(curl -s $URL | jq -r ".\"$PACKAGE\"")
     kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/${PACKAGE}@${VERSION}
     ```
 
@@ -412,9 +412,9 @@ cd pbmm-landingzone
     - Experimentation
 
       ```shell
+      URL="https://raw.githubusercontent.com/GoogleCloudPlatform/pubsec-declarative-toolkit/main/.release-please-manifest.json"
       PACKAGE="solutions/experimentation/core-landing-zone"
-      #VERSION=$(curl -s $URL | jq -r ".\"$PACKAGE\"")
-      VERSION=main
+      VERSION=$(curl -s $URL | jq -r ".\"$PACKAGE\"")
       kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/${PACKAGE}@${VERSION}
       ```
 
@@ -423,9 +423,9 @@ cd pbmm-landingzone
     - or DEV, PREPROD, PROD
 
       ```shell
+      URL="https://raw.githubusercontent.com/GoogleCloudPlatform/pubsec-declarative-toolkit/main/.release-please-manifest.json"
       PACKAGE="solutions/core-landing-zone"
-      #VERSION=$(curl -s $URL | jq -r ".\"$PACKAGE\"")
-      VERSION=main
+      VERSION=$(curl -s $URL | jq -r ".\"$PACKAGE\"")
       kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/${PACKAGE}@${VERSION}
       ```
 


### PR DESCRIPTION
Use the main release for all kpt packages until we fix the URL and the json parsing around URL="https://api.github.com/repos/GoogleCloudPlatform/pubsec-declarative-toolkit/releases"

These 3 script sections were tested in one of my organizations
Later I will look at the full fix for release extraction from the json release URL above - no time right now.
