### PR TITLE
Update to Fortinet Hub ENV Package

### DIFF
--- a/solutions/project/hub-env/project.yaml
+++ b/solutions/project/hub-env/project.yaml
@@ -20,7 +20,6 @@ metadata:
   namespace: projects
   annotations:
     cnrm.cloud.google.com/auto-create-network: "false"
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/hierarchy/Folder/services-infrastructure
 spec:
   name: hub-project-id # kpt-set: ${hub-project-id}
   billingAccountRef:

--- a/solutions/project/hub-env/setters.yaml
+++ b/solutions/project/hub-env/setters.yaml
@@ -14,6 +14,8 @@ data:
   # Naming Convention for project-id : <tenant-code><environment-code>m<data-classification>-<project-owner>-<user defined string>
   # Max 30 characters
   hub-project-id: xxdmu-admin1-projectname
+  # Project ID of the project hosting the config controller instance
+  management-project-id: management-project-id
   # Identity that should be allowed to access the management VM using IAP TCP forwarding
   # https://cloud.google.com/iap/docs/using-tcp-forwarding
   hub-admin: group:group@domain.com


### PR DESCRIPTION
This PR removes the depends-on annotation from the hub project and adds the `management-project-id` variable to the setters file.