### PR TITLE
#625 - 446 N2_CPUS quota of 8 requires fortigate management vm to use e2-standard and leave n2-standard to FG VMs

### DIFF
--- a/solutions/project/hub-env/fortigate/management-vm/management-vm.yaml
+++ b/solutions/project/hub-env/fortigate/management-vm/management-vm.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   resourceID: management-instance
   description: Hub Management VM
-  machineType: n2-standard-2
+  machineType: e2-standard-2
   zone: northamerica-northeast1-a
   scheduling:
     automaticRestart: true


### PR DESCRIPTION
… e2-standard and leave n2-standard to FG VMs

see testing in #625 and #446

essentially out of the box organizations will have a N2_CPUS quota of 8. Attempting to increase this quota does not always get approved even for 10 vCores

Temporary fix is use a slightly different machine type e2-standard-2 for just the management VM

VMs come up after this

```
Status:
  Conditions:
    Last Transition Time:  2023-10-27T21:07:26Z
    Message:               The resource is up to date
    Reason:                UpToDate
    Status:                True
    Type:                  Ready
  Cpu Platform:            Intel Cascade Lake
  Current Status:          RUNNING
  Instance Id:             5974440820601886829
  Label Fingerprint:       Z9VAAJ71T-w=
  Metadata Fingerprint:    GXJWD0MkUvs=
  Observed Generation:     7
  Self Link:               https://www.googleapis.com/compute/v1/projects/xxdmu-admin4-ls/zones/northamerica-northeast1-b/instances/fgt-secondary-instance
  Tags Fingerprint:        tvYV2XqMUG4=
Events:
  Type     Reason        Age                    From                        Message
  ----     ------        ----                   ----                        -------
  Warning  UpdateFailed  31m (x2153 over 3d6h)  computeinstance-controller  Update call failed: error applying desired state: summary: Error waiting for instance to create: Quota 'N2_CPUS' exceeded.  Limit: 8.0 in region northamerica-northeast1.
           metric name = compute.googleapis.com/n2_cpus
           limit name = N2-CPUS-per-project-region
           limit = 8
           dimensions = map[region:northamerica-northeast1]
  Normal   Updating  5m36s (x2190 over 3d6h)  computeinstance-controller  Update in progress
root_@cloudshell:~/pdt-ls/obriensystems/pubsec-declarative-toolkit/solutions/project (kcc-boot-ls-8704)$ ^C
root_@cloudshell:~/pdt-ls/obriensystems/pubsec-declarative-toolkit/solutions/project (kcc-boot-ls-8704)$ kubectl get gcp -n networking | grep computeinstance
computeinstancegroup.compute.cnrm.cloud.google.com/hub-fgt-primary-umig     3d6h   True    UpToDate   5m53s
computeinstancegroup.compute.cnrm.cloud.google.com/hub-fgt-secondary-umig   3d6h   True    UpToDate   4m11s
computeinstance.compute.cnrm.cloud.google.com/hub-fgt-primary-instance     3d6h   True    UpToDate   6m38s
computeinstance.compute.cnrm.cloud.google.com/hub-fgt-secondary-instance   3d6h   True    UpToDate   4m11s
computeinstance.compute.cnrm.cloud.google.com/hub-management-instance      3d6h   True    UpToDate   4m30s
```
<img width="2171" alt="Screenshot 2023-10-27 at 17 25 45" src="https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/assets/24765473/c3713ebc-8915-45fc-893b-2f468586b126">