### PR TITLE
fix: cleanup yaml comments for some examples

### DIFF
--- a/examples/landing-zone-v2/configconnector/tier3/cloud-armor/security-policy.yaml
+++ b/examples/landing-zone-v2/configconnector/tier3/cloud-armor/security-policy.yaml
@@ -14,6 +14,8 @@
 #########
 # creates a cloud armor policy with rules
 # the target load balancer is attached from its ComputeBackendService resource
+# SC-5, SC-5(2) - Deploy Web Application Firewall in front of public facing web applications for additional inspection of incoming traffic using Cloud armor policy
+# Cloud armor policy is made up of rules that filter traffic based on conditions such as incoming request ip address before it reaches target load balancer backend services.
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeSecurityPolicy
 metadata:

--- a/examples/landing-zone-v2/configconnector/tier3/cloud-armor/setters.yaml
+++ b/examples/landing-zone-v2/configconnector/tier3/cloud-armor/setters.yaml
@@ -30,12 +30,15 @@ data:
   ##########################
   #
   # the project id that was created by the client-project-setup
+  # customization: required
   project-id: project12345
   #
   ##########################
   # Workload
   ##########################
   #
+  # workload name given to uniquely identify the policy
+  # customization: required
   workload-name: sample-workload
   #
   ##########################

--- a/examples/landing-zone-v2/configconnector/tier3/ssl-policies/setters.yaml
+++ b/examples/landing-zone-v2/configconnector/tier3/ssl-policies/setters.yaml
@@ -30,6 +30,7 @@ data:
   ##########################
   #
   # The project id that was created by the client-project-setup
+  # customization: required
   project-id: project-id-12345
   #
   ##########################

--- a/examples/landing-zone-v2/configconnector/tier3/ssl-policies/ssl-policy-tls-1.2.yaml
+++ b/examples/landing-zone-v2/configconnector/tier3/ssl-policies/ssl-policy-tls-1.2.yaml
@@ -14,7 +14,7 @@
 #########
 # https://www.cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062
 #########
-# SSL policy with minimum TLS 1.2
+# SC-8, SC-13 - SSL policy with minimum TLS 1.2
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeSSLPolicy
 metadata:
@@ -23,6 +23,7 @@ metadata:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
   description: CCCS approved TLS 1.2 policy
+  # SC-8, SC-13
   minTlsVersion: TLS_1_2
   profile: CUSTOM
   customFeatures:


### PR DESCRIPTION
cleanup setters / security controls comments (issue #617) for these packages:

- examples/landing-zone-v2/configconnector/tier3/cloud-armor/
- examples/landing-zone-v2/configconnector/tier3/ssl-policies/

credits to @anoopsidhu-ssc @CraigBaltzer @seanwilkens-ssc @davelanglois-ssc 