### PR TITLE
fix: yaml comments cleanup

### DIFF
--- a/solutions/gke/configconnector/gke-cluster-autopilot/README.md
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/README.md
@@ -59,28 +59,28 @@ To fix this, you update the `root-sync` resource to include the override section
 
 ## Setters
 
-|              Name               |                     Value                      | Type  | Count |
-|---------------------------------|------------------------------------------------|-------|-------|
-| client-name                     | client1                                        | str   |    18 |
-| cluster-name                    | autopilot1-gke                                 | str   |    36 |
-| gke-to-azdo-priority            |                                           2000 | int   |     1 |
-| gke-to-docker-priority          |                                           2002 | int   |     1 |
-| gke-to-github-priority          |                                           2001 | int   |     1 |
-| host-project-id                 | host-project-12345                             | str   |     6 |
-| host-project-vpc                | host-project-vpc                               | str   |     2 |
-| location                        | northamerica-northeast1                        | str   |     5 |
-| master-authorized-networks-cidr | [cidrBlock: 10.1.1.5/32displayName: bastion]   | array |     1 |
-| masterIpv4CidrBlock             | 172.16.0.0/28                                  | str   |     1 |
-| masterIpv4Range                 | ["172.16.0.0/28"]                              | array |     0 |
-| podIpv4Range                    | ["240.1.0.0/21"]                               | array |     1 |
-| primaryIpv4Range                | ["10.1.32.0/24"]                               | array |     3 |
-| project-id                      | project-12345                                  | str   |    51 |
-| repo-branch                     | main                                           | str   |     1 |
-| repo-dir                        | csync/tier3/kubernetes/<fleet-id>/deploy/<env> | str   |     1 |
-| repo-url                        | tier34-repo-to-observe                         | str   |     1 |
-| subnet-pod-cidr                 | 240.1.0.0/21                                   | str   |     1 |
-| subnet-primary-cidr             | 10.1.32.0/24                                   | str   |     1 |
-| subnet-services-cidr            | 10.1.33.0/24                                   | str   |     1 |
+|              Name               |                        Value                         | Type  | Count |
+|---------------------------------|------------------------------------------------------|-------|-------|
+| client-name                     | client1                                              | str   |    18 |
+| cluster-name                    | autopilot1-gke                                       | str   |    36 |
+| gke-to-azdo-priority            |                                                 2000 | int   |     1 |
+| gke-to-docker-priority          |                                                 2002 | int   |     1 |
+| gke-to-github-priority          |                                                 2001 | int   |     1 |
+| host-project-id                 | host-project-12345                                   | str   |     6 |
+| host-project-vpc                | host-project-vpc                                     | str   |     2 |
+| location                        | northamerica-northeast1                              | str   |     5 |
+| master-authorized-networks-cidr | [cidrBlock: 10.1.1.5/32displayName: gke-admin-proxy] | array |     1 |
+| masterIpv4CidrBlock             | 172.16.0.0/28                                        | str   |     1 |
+| masterIpv4Range                 | ["172.16.0.0/28"]                                    | array |     0 |
+| podIpv4Range                    | ["240.1.0.0/21"]                                     | array |     1 |
+| primaryIpv4Range                | ["10.1.32.0/24"]                                     | array |     3 |
+| project-id                      | project-12345                                        | str   |    51 |
+| repo-branch                     | main                                                 | str   |     1 |
+| repo-dir                        | csync/tier3/kubernetes/<fleet-id>/deploy/<env>       | str   |     1 |
+| repo-url                        | tier34-repo-to-observe                               | str   |     1 |
+| subnet-pod-cidr                 | 240.1.0.0/21                                         | str   |     1 |
+| subnet-primary-cidr             | 10.1.32.0/24                                         | str   |     1 |
+| subnet-services-cidr            | 10.1.33.0/24                                         | str   |     1 |
 
 ## Sub-packages
 

--- a/solutions/gke/configconnector/gke-cluster-autopilot/gke.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/gke.yaml
@@ -13,6 +13,8 @@
 # limitations under the License.
 ######
 # GKE Autopilot Cluster
+# AC-4, SC-7, SC-7(3) - Authorized IP ranges are defined on Kubernetes services
+# SC-28, SC-28(1) - Protection of ETCD database at rest
 # https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerCluster
@@ -32,6 +34,7 @@ spec:
       serviceAccountRef:
         name: cluster-name-sa # kpt-set: ${cluster-name}-sa
   description: GKE Autopilot Cluster
+  # SC-28, SC-28(1)
   databaseEncryption:
     keyName: projects/project-id/locations/northamerica-northeast1/keyRings/cluster-name-kmskeyring/cryptoKeys/cluster-name-etcd-key # kpt-set: projects/${project-id}/locations/${location}/keyRings/${cluster-name}-kmskeyring/cryptoKeys/${cluster-name}-etcd-key
     state: ENCRYPTED
@@ -56,6 +59,7 @@ spec:
     dailyMaintenanceWindow:
       startTime: 05:00
       duration: 04:00
+  # AC-4, SC-7, SC-7(3)
   masterAuthorizedNetworksConfig:
     cidrBlocks: # kpt-set: ${master-authorized-networks-cidr}
       - cidrBlock: 10.1.1.5/32

--- a/solutions/gke/configconnector/gke-cluster-autopilot/host-project/subnet.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/host-project/subnet.yaml
@@ -16,8 +16,9 @@
 # - logging enabled for flow logs https://cloud.google.com/vpc/docs/using-flow-logs
 # - private google access enabled https://cloud.google.com/vpc/docs/private-google-access
 #########
-# GKE Subnet
-# AC-4, AC-4(21)
+# AC-4, AC-4(21) - GKE Subnet that has private google access enabled and flow logs enabled
+# Private Google Access allows to access external IP address of Google apis and services in a secured way
+# Flow logs on subnet captures all traffic for a subnet and publishes to cloud logging
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeSubnetwork
 metadata:

--- a/solutions/gke/configconnector/gke-cluster-autopilot/securitycontrols.md
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/securitycontrols.md
@@ -3,16 +3,53 @@
 <!-- BEGINNING OF SECURITY CONTROLS LIST -->
 |Security Control|File Name|Resource Name|
 |---|---|---|
+|AC-3|./service-account.yaml|cluster-name-sa|
+|AC-3|./service-account.yaml|cluster-name-sa-artifactregistry-reader-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-artifactregistry-reader-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-logwriter-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-logwriter-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-metricwriter-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-metricwriter-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-monitoring-viewer-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-monitoring-viewer-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-secretmanager-secretaccessor-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-secretmanager-secretaccessor-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-stackdriver-metadata-writer-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-stackdriver-metadata-writer-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-storage-object-viewer-permissions|
+|AC-3|./service-account.yaml|cluster-name-sa-storage-object-viewer-permissions|
+|AC-3|./service-account.yaml|project-id-tier3-sa-serviceaccount-user-cluster-name-sa-permissions|
+|AC-3|./service-account.yaml|project-id-tier3-sa-serviceaccount-user-cluster-name-sa-permissions|
+|AC-3|./service-account.yaml|project-id-tier3-sa-serviceaccount-user-cluster-name-sa-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-artifactregistry-reader-permissions|
 |AC-3(7)|./service-account.yaml|cluster-name-sa-artifactregistry-reader-permissions|
 |AC-3(7)|./service-account.yaml|cluster-name-sa-logwriter-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-logwriter-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-metricwriter-permissions|
 |AC-3(7)|./service-account.yaml|cluster-name-sa-metricwriter-permissions|
 |AC-3(7)|./service-account.yaml|cluster-name-sa-monitoring-viewer-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-monitoring-viewer-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-secretmanager-secretaccessor-permissions|
 |AC-3(7)|./service-account.yaml|cluster-name-sa-secretmanager-secretaccessor-permissions|
 |AC-3(7)|./service-account.yaml|cluster-name-sa-stackdriver-metadata-writer-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-stackdriver-metadata-writer-permissions|
+|AC-3(7)|./service-account.yaml|cluster-name-sa-storage-object-viewer-permissions|
 |AC-3(7)|./service-account.yaml|cluster-name-sa-storage-object-viewer-permissions|
 |AC-3(7)|./service-account.yaml|project-id-tier3-sa-serviceaccount-user-cluster-name-sa-permissions|
 |AC-3(7)|./service-account.yaml|project-id-tier3-sa-serviceaccount-user-cluster-name-sa-permissions|
+|AC-3(7)|./service-account.yaml|project-id-tier3-sa-serviceaccount-user-cluster-name-sa-permissions|
+|AC-4|./gke.yaml|cluster-name|
+|AC-4|./gke.yaml|cluster-name|
 |AC-4|./host-project/subnet.yaml|project-id-cluster-name-snet|
 |AC-4(21)|./host-project/subnet.yaml|project-id-cluster-name-snet|
+|SC-28|./gke.yaml|cluster-name|
+|SC-28|./gke.yaml|cluster-name|
+|SC-28(1)|./gke.yaml|cluster-name|
+|SC-28(1)|./gke.yaml|cluster-name|
+|SC-7|./gke.yaml|cluster-name|
+|SC-7|./gke.yaml|cluster-name|
+|SC-7(3)|./gke.yaml|cluster-name|
+|SC-7(3)|./gke.yaml|cluster-name|
 
 <!-- END OF SECURITY CONTROLS LIST -->

--- a/solutions/gke/configconnector/gke-cluster-autopilot/service-account.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/service-account.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ######
-# GCP SA
+# AC-3(7), AC-3 - GCP Service Account
 # CIS GKE Benchmark Recommendation: 6.2.1. Prefer not running GKE clusters using the Compute Engine default service account
 # https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
@@ -25,8 +25,7 @@ metadata:
 spec:
   displayName: cluster-name-sa # kpt-set: ${cluster-name}-sa
 ---
-# Grant GCP role Logging Log Writer to GCP SA on Service Project
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant GCP role Logging Log Writer to GCP SA on Service Project
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -35,6 +34,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -43,8 +43,7 @@ spec:
   role: roles/logging.logWriter
   member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
 ---
-# Grant GCP role Monitoring Metric Writer to GCP SA on Service Project
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant GCP role Monitoring Metric Writer to GCP SA on Service Project
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -53,6 +52,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -61,8 +61,7 @@ spec:
   role: roles/monitoring.metricWriter
   member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
 ---
-# Grant GCP role Monitoring Viewer to GCP SA on Service Project
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant GCP role Monitoring Viewer to GCP SA on Service Project
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -71,6 +70,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -79,8 +79,7 @@ spec:
   role: roles/monitoring.viewer
   member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
 ---
-# Grant GCP Storage Object Viewer to GCP SA on Service Project for Artifact Registry access
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant GCP Storage Object Viewer to GCP SA on Service Project for Artifact Registry access
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -89,6 +88,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -97,8 +97,7 @@ spec:
   role: roles/storage.objectViewer
   member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
 ---
-# Grant stackdriver.resourceMetadata.writer to GCP SA on Service Project for Logging access
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant stackdriver.resourceMetadata.writer to GCP SA on Service Project for Logging access
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -107,6 +106,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -115,8 +115,7 @@ spec:
   role: roles/stackdriver.resourceMetadata.writer
   member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
 ---
-# Grant artifactregistry.reader to GCP SA on Service Project for Artifact Registry access
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant artifactregistry.reader to GCP SA on Service Project for Artifact Registry access
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -125,6 +124,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -133,8 +133,7 @@ spec:
   role: roles/artifactregistry.reader
   member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
 ---
-# Grant secretmanager.secretAccessor to GCP SA on Service Project for Secret access
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant secretmanager.secretAccessor to GCP SA on Service Project for Secret access
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -143,6 +142,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -152,8 +152,7 @@ spec:
   member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
 ---
 # TODO: activate once the service account can be used by the control plane
-# # Grant cloudkms.cryptoKeyEncrypterDecrypter to GCP SA on Service Project for Cloud KMS access
-# # AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant cloudkms.cryptoKeyEncrypterDecrypter to GCP SA on Service Project for Cloud KMS access
 # apiVersion: iam.cnrm.cloud.google.com/v1beta1
 # kind: IAMPolicyMember
 # metadata:
@@ -170,8 +169,7 @@ spec:
 #   role: roles/cloudkms.cryptoKeyEncrypterDecrypter
 #   member: "serviceAccount:cluster-name-sa@project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${cluster-name}-sa@${project-id}.iam.gserviceaccount.com
 # ---
-# Grant IAM service account user to Tier3 SA on cluster-name SA
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant IAM service account user to Tier3 SA on cluster-name SA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -180,6 +178,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount

--- a/solutions/gke/configconnector/gke-cluster-autopilot/setters.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/setters.yaml
@@ -30,22 +30,29 @@ data:
   ##########################
   #
   # Name for the client, lowercase only
+  # customization: required
   client-name: client1
   #
   ##########################
   # Project
   ##########################
   #
-  # The project id that was created by the client-project-setup. This id will also becomes the Anthos Fleet id
+  # The project id that was created by the client-project-setup.
+  # This id will also becomes the Anthos Fleet id
+  # customization: required
   project-id: project-12345
   #
   ##########################
   # Network Host Project
   ##########################
   #
-  # the client network host project id
+  # the host project for this client created in client-landing-zone package deployment
+  # customization: required
   host-project-id: host-project-12345
-  # VPC to deploy the subnet - K8S resource name
+  #
+  # VPC to deploy the subnet, the value must match the kubernetes resources 'metadata.name'
+  # created in client-landing-zone package deployment
+  # customization: required
   host-project-vpc: host-project-vpc
   #
   ##########################
@@ -53,29 +60,49 @@ data:
   ##########################
   #
   # name of this GKE cluster
+  # customization: required
   cluster-name: autopilot1-gke
+  #
   # the region where to deploy this GKE cluster
+  # customization: optional
   location: northamerica-northeast1
+  #
   # the master control plane cidr for kind ContainerCluster
+  # Must be unique within the VPC. Looking at the VPC's routing table can help determine this values
+  # customization: optional
   masterIpv4CidrBlock: 172.16.0.0/28
+  #
   # the master control plane range for kind ComputeFirewall (same as masterIpv4CidrBlock but using list)
+  # customization: optional
   masterIpv4Range: |
     - "172.16.0.0/28"
-  # the master authorized networks cidr - bastion ip
+  #
+  # the master authorized networks cidr - gke admin proxy ip
+  # customization: required
   master-authorized-networks-cidr: |
     - cidrBlock: 10.1.1.5/32
-      displayName: bastion
+      displayName: gke-admin-proxy
+  #
   # subnet IP ranges
+  # Must be unique within the VPC. Looking at the VPC's routing table can help determine these values
+  # customization: optional
   subnet-primary-cidr: 10.1.32.0/24
   subnet-services-cidr: 10.1.33.0/24
   subnet-pod-cidr: 240.1.0.0/21
+  #
   # the pod range for kind ComputeFirewall (same as subnet-pod-cidr but using list)
+  # customization: optional
   podIpv4Range: |
     - "240.1.0.0/21"
+  #
   # the primary range for kind ComputeFirewall (same as subnet-primary-cidr but using list)
+  # customization: optional
   primaryIpv4Range: |
     - "10.1.32.0/24"
-  # firewall policies priority ( cannot overlap with any existing policy id)
+  #
+  # firewall policies priority, this cannot overlap with any existing policy id
+  # can verify by checking the firewall policies for the host project
+  # customization: required (only optional for the client's first cluster)
   gke-to-azdo-priority: 2000
   gke-to-github-priority: 2001
   gke-to-docker-priority: 2002
@@ -85,14 +112,20 @@ data:
   ##########################
   #
   # Used for the initial root sync of the GKE cluster (GitHub, Azure DevOps, etc.)
+  # The repo stores the manifests for the kubernetes resources to be deployed by this GKE cluster
   #
   # the git repo URL, for example
   # https://github.com/GITHUB-ORG/REPO-NAME
   # https://AZDO-ORG@dev.azure.com/AZDO-ORG/AZDO-PROJECT/_git/REPO-NAME
+  # customization: required
   repo-url: tier34-repo-to-observe
+  #
   # the branch to check out (usually main)
+  # customization: optional
   repo-branch: main
+  #
   # the directory to observe for YAML manifests
+  # customization: required
   repo-dir: csync/tier3/kubernetes/<fleet-id>/deploy/<env>
   #
   ##########################

--- a/solutions/gke/configconnector/gke-defaults/README.md
+++ b/solutions/gke/configconnector/gke-defaults/README.md
@@ -24,11 +24,14 @@ loaded in the config controller.
 |------------------|---------------------------|-------|-------|
 | certificate-id   |                  12345678 | int   |     1 |
 | certificate-name | certificate-name          | str   |     3 |
-| client-name      | client1                   | str   |     6 |
+| client-name      | client1                   | str   |     8 |
+| dns-project-id   | dns-project-id            | str   |     1 |
 | domains          | [example.com]             | array |     1 |
-| gateway-name     | gateway-name              | str   |     2 |
+| gateway-name     | gateway-name              | str   |     3 |
 | host-project-id  | host-project-12345        | str   |     0 |
-| project-id       | project-12345             | str   |    10 |
+| metadata-name    | metadata-name             | str   |     1 |
+| project-id       | project-12345             | str   |    12 |
+| spec-name        | dns-name                  | str   |     1 |
 | team-gkeviewer   | group:client1@example.com | str   |     6 |
 
 ## Sub-packages

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/dns.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/dns.yaml
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# create a DNS A record referencing the gateway address
-# SC-22
+# SC-22 - create a DNS A record referencing the external public loadbalancer gateway ip address
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSRecordSet
 metadata:

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/setters.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/setters.yaml
@@ -29,18 +29,25 @@ data:
   # Client
   ##########################
   #
-  # Project that has the public dns zone. Usually the client host project that was created by the client-landing-zone package
+  # Project that has the public dns zone.
+  # Usually the client host project that was created by the client-landing-zone package
+  # customization: required
   dns-project-id: dns-project-12345
   #
   ##########################
   # Gateway
   ##########################
   #
-  # The DNSRecordset.metadata.name (a.k.a kubernetes resource name)
+  # This value is used to define the kubernetes resource name of that DNSRecordset
+  # customization: required
   metadata-name: sample-name-recordset
-  # The DNSRecordset.spec.name
+  #
+  # The value must match the kubernetes DNSRecordset.spec.name resource
+  # customization: required
   spec-name: "sample-name.example.com."
+  #
   # The Gateway name
+  # customization: required
   gateway-name: sample-gateway
   #
   ##########################
@@ -48,8 +55,11 @@ data:
   ##########################
   #
   # Name for the client, lowercase only
+  # customization: required
   client-name: client1
+  #
   # The project id that was created by the client-project-setup
+  # customization: required
   project-id: project-12345
   #
   ##########################

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/setters.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/setters.yaml
@@ -29,7 +29,8 @@ data:
   # Gateway
   ##########################
   #
-  # The name of the gateway resource
+  # The name of the gateway resource that is created in the kubernetes/cluster-defaults/gateway package.
+  # customization: required
   gateway-name: sample-gateway
   #
   ##########################
@@ -37,6 +38,7 @@ data:
   ##########################
   #
   # The project id that was created by the client-project-setup
+  # customization: required
   project-id: project-12345
   #
   ##########################

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate/setters.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate/setters.yaml
@@ -30,10 +30,15 @@ data:
   ##########################
   #
   # the unique identifier for the resource
+  # customization: required
   certificate-id: 12345678
+  #
   # a resource name for this certificate
+  # customization: required
   certificate-name: sample-name
+  #
   # domains for which a managed SSL certificate will be valid. There can be up to 100 domains in this list.
+  # customization: required
   domains: |
     - sample-name.example.com
   #
@@ -42,6 +47,7 @@ data:
   ##########################
   #
   # The project id that was created by the client-project-setup
+  # customization: required
   project-id: project-12345
   #
   ##########################

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate/ssl.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/ssl-certificate/ssl.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# Google Managed Classic SSL certificate
+# SC-8 - Google Managed Classic SSL certificate that would be used by Gateway controller that would target external public load balancer
 # Warning! requires the alpha resource loaded in the config controller
 # https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/crds/compute_v1alpha1_computemanagedsslcertificate.yaml
 # TODO: fix error message : Update call failed: error applying desired state: summary: doesn't support update
@@ -24,6 +24,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/state-into-spec: absent
 spec:
+  # SC-8
   certificateId: 12345678 # kpt-set: ${certificate-id}
   description: certificate-name Managed SSL Certificate # kpt-set: ${certificate-name} Managed SSL Certificate
   managed:

--- a/solutions/gke/configconnector/gke-defaults/project-iam.yaml
+++ b/solutions/gke/configconnector/gke-defaults/project-iam.yaml
@@ -14,8 +14,7 @@
 #########
 # Client viewer permissions for GKE, logging, and monitoring
 #########
-# Grant role: roles/container.clusterViewer on the GKE Cluster project to client group
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant role: roles/container.clusterViewer on the GKE Cluster project to client group
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -23,6 +22,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -31,8 +31,7 @@ spec:
   role: roles/container.clusterViewer
   member: team-gkeviewer # kpt-set: ${team-gkeviewer}
 ---
-# Grant role: roles/logging.viewer on the GKE Cluster project to client group
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant role: roles/logging.viewer on the GKE Cluster project to client group
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -40,6 +39,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -48,8 +48,7 @@ spec:
   role: roles/logging.viewer
   member: team-gkeviewer # kpt-set: ${team-gkeviewer}
 ---
-# Grant role: roles/monitoring.viewer on the GKE Cluster project to client group
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant role: roles/monitoring.viewer on the GKE Cluster project to client group
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -57,6 +56,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -65,8 +65,7 @@ spec:
   role: roles/monitoring.viewer
   member: team-gkeviewer # kpt-set: ${team-gkeviewer}
 ---
-# Grant role: roles/monitoring.dashboardEditor on the GKE Cluster project to client group
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant role: roles/monitoring.dashboardEditor on the GKE Cluster project to client group
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -74,6 +73,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -82,8 +82,7 @@ spec:
   role: roles/monitoring.dashboardEditor
   member: team-gkeviewer # kpt-set: ${team-gkeviewer}
 ---
-# Grant role: roles/pubsub.viewer on the GKE Cluster project to client group
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant role: roles/pubsub.viewer on the GKE Cluster project to client group
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -91,6 +90,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -99,8 +99,7 @@ spec:
   role: roles/pubsub.viewer
   member: team-gkeviewer # kpt-set: ${team-gkeviewer}
 ---
-# Grant role: roles/pubsub.subscriber on the GKE Cluster project to client group
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
+# AC-3(7), AC-3 - Grant role: roles/pubsub.subscriber on the GKE Cluster project to client group
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -108,6 +107,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project

--- a/solutions/gke/configconnector/gke-defaults/securitycontrols.md
+++ b/solutions/gke/configconnector/gke-defaults/securitycontrols.md
@@ -1,6 +1,34 @@
 # Security Controls
 
 <!-- BEGINNING OF SECURITY CONTROLS LIST -->
-
+|Security Control|File Name|Resource Name|
+|---|---|---|
+|AC-3|./project-iam.yaml|containerclusterviewer-permissions|
+|AC-3|./project-iam.yaml|containerclusterviewer-permissions|
+|AC-3|./project-iam.yaml|loggingviewer-permissions|
+|AC-3|./project-iam.yaml|loggingviewer-permissions|
+|AC-3|./project-iam.yaml|monitoringdashboardeditor-permissions|
+|AC-3|./project-iam.yaml|monitoringdashboardeditor-permissions|
+|AC-3|./project-iam.yaml|monitoringviewer-permissions|
+|AC-3|./project-iam.yaml|monitoringviewer-permissions|
+|AC-3|./project-iam.yaml|pubsubsubscriber-permissions|
+|AC-3|./project-iam.yaml|pubsubsubscriber-permissions|
+|AC-3|./project-iam.yaml|pubsubviewer-permissions|
+|AC-3|./project-iam.yaml|pubsubviewer-permissions|
+|AC-3(7)|./project-iam.yaml|containerclusterviewer-permissions|
+|AC-3(7)|./project-iam.yaml|containerclusterviewer-permissions|
+|AC-3(7)|./project-iam.yaml|loggingviewer-permissions|
+|AC-3(7)|./project-iam.yaml|loggingviewer-permissions|
+|AC-3(7)|./project-iam.yaml|monitoringdashboardeditor-permissions|
+|AC-3(7)|./project-iam.yaml|monitoringdashboardeditor-permissions|
+|AC-3(7)|./project-iam.yaml|monitoringviewer-permissions|
+|AC-3(7)|./project-iam.yaml|monitoringviewer-permissions|
+|AC-3(7)|./project-iam.yaml|pubsubsubscriber-permissions|
+|AC-3(7)|./project-iam.yaml|pubsubsubscriber-permissions|
+|AC-3(7)|./project-iam.yaml|pubsubviewer-permissions|
+|AC-3(7)|./project-iam.yaml|pubsubviewer-permissions|
+|SC-22|./gateway-setup/dns/dns.yaml|metadata-name|
+|SC-8|./gateway-setup/ssl-certificate/ssl.yaml|certificate-name-compute-sslcertificate|
+|SC-8|./gateway-setup/ssl-certificate/ssl.yaml|certificate-name-compute-sslcertificate|
 
 <!-- END OF SECURITY CONTROLS LIST -->

--- a/solutions/gke/configconnector/gke-defaults/setters.yaml
+++ b/solutions/gke/configconnector/gke-defaults/setters.yaml
@@ -30,10 +30,15 @@ data:
   ##########################
   #
   # Name for the client, lowercase only
+  # customization: required
   client-name: 'client1'
+  #
   # group to grant gke, logging, and monitoring viewer permissions
+  # customization: required
   team-gkeviewer: 'group:client1@example.com'
-  # the host project for this client
+  #
+  # the host project for this client created in client-landing-zone package deployment
+  # customization: required
   host-project-id: host-project-12345
   #
   ##########################
@@ -41,6 +46,7 @@ data:
   ##########################
   #
   # the project id that was created by the client-project-setup
+  # customization: required
   project-id: project-12345
   #
   ##########################

--- a/solutions/gke/configconnector/gke-workload-identity/securitycontrols.md
+++ b/solutions/gke/configconnector/gke-workload-identity/securitycontrols.md
@@ -3,7 +3,17 @@
 <!-- BEGINNING OF SECURITY CONTROLS LIST -->
 |Security Control|File Name|Resource Name|
 |---|---|---|
+|AC-3|./workload-identity.yaml|workload-name-sa|
+|AC-3|./workload-identity.yaml|workload-name-sa|
+|AC-3|./workload-identity.yaml|workload-name-sa-secretaccessor-permissions|
+|AC-3|./workload-identity.yaml|workload-name-sa-secretaccessor-permissions|
+|AC-3|./workload-identity.yaml|workload-name-sa-secretmanager-secretaccessor-permissions|
+|AC-3|./workload-identity.yaml|workload-name-sa-secretmanager-secretaccessor-permissions|
+|AC-3(7)|./workload-identity.yaml|workload-name-sa|
+|AC-3(7)|./workload-identity.yaml|workload-name-sa|
 |AC-3(7)|./workload-identity.yaml|workload-name-sa-secretaccessor-permissions|
+|AC-3(7)|./workload-identity.yaml|workload-name-sa-secretaccessor-permissions|
+|AC-3(7)|./workload-identity.yaml|workload-name-sa-secretmanager-secretaccessor-permissions|
 |AC-3(7)|./workload-identity.yaml|workload-name-sa-secretmanager-secretaccessor-permissions|
 
 <!-- END OF SECURITY CONTROLS LIST -->

--- a/solutions/gke/configconnector/gke-workload-identity/setters.yaml
+++ b/solutions/gke/configconnector/gke-workload-identity/setters.yaml
@@ -30,6 +30,7 @@ data:
   ##########################
   #
   # Name for the client, lowercase only
+  # customization: required
   client-name: 'client1'
   #
   ##########################
@@ -37,12 +38,16 @@ data:
   ##########################
   #
   # the project id that was created by the client-project-setup
+  # customization: required
   project-id: project-12345
   #
   ##########################
   # Workload
   ##########################
   #
+  # workload name given to service account to be created
+  # lowercase only, max 27 characters
+  # customization: required
   workload-name: sample-workload
   #
   ##########################

--- a/solutions/gke/configconnector/gke-workload-identity/workload-identity.yaml
+++ b/solutions/gke/configconnector/gke-workload-identity/workload-identity.yaml
@@ -20,7 +20,7 @@
 # Additional roles can be granted to this service account to provide applications access to other Google services.
 #########
 # GCP SA that will access Google services.
-# This GCP SA is bound to a Kubernetes SA
+# AC-3(7), AC-3 - This GCP SA is bound to a Kubernetes SA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
@@ -29,11 +29,11 @@ metadata:
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
+  # AC-3(7), AC-3
   displayName: workload-name-sa # kpt-set: ${workload-name}-sa
 ---
-# Grant secretmanager.secretAccessor to GCP SA on Service Project for Secret access
+# AC-3(7), AC-3 - Grant secretmanager.secretAccessor to GCP SA on Service Project for Secret access
 # This enables the GCP SA to access Google Secrets
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
@@ -42,6 +42,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -50,9 +51,8 @@ spec:
   role: roles/secretmanager.secretAccessor
   member: "serviceAccount:workload-name-sa@bddmu-mvp-demo.iam.gserviceaccount.com" # kpt-set: serviceAccount:${workload-name}-sa@${project-id}.iam.gserviceaccount.com
 ---
-# Grant GCP role iam.workloadIdentityUser to GCP SA to allow the Kubernetes SA to impersonate the GCP SA
+# AC-3(7), AC-3 - Grant GCP role iam.workloadIdentityUser to GCP SA to allow the Kubernetes SA to impersonate the GCP SA
 # This binding allows the Kubernetes service account to act as the GCP IAM service account.
-# AC-3(7) - ACCESS ENFORCEMENT | ROLE-BASED ACCESS CONTROL
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy
 metadata:
@@ -61,6 +61,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
+  # AC-3(7), AC-3
   resourceRef:
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount

--- a/solutions/gke/kubernetes/cluster-defaults/gateway/backendpolicy/setters.yaml
+++ b/solutions/gke/kubernetes/cluster-defaults/gateway/backendpolicy/setters.yaml
@@ -27,7 +27,14 @@ data:
   ##########################
   # Workload
   ##########################
+  #
+  # the name of the workload that was created in the configcontroller/gke-workload-identity package
+  # lowercase only, max 27 characters
+  # customization: required
   workload-name: sample-workload
+  #
+  # The kubernetes service which is referenced by the GCPBackendPolicy
+  # customization: required
   service-name: sample-service
   #
   ##########################

--- a/solutions/gke/kubernetes/cluster-defaults/gateway/gateway-global.yaml
+++ b/solutions/gke/kubernetes/cluster-defaults/gateway/gateway-global.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
+# SC-5, SC-5(2), SC-8 - Deploy public external load balancer in front of public facing web applications for additional inspection of incoming traffic and enforcing additional security policies such as ssl etc.
 # Gateway using an external global load balancer and a SSL certificate
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
@@ -19,6 +20,7 @@ metadata:
   name: external-gateway-name # kpt-set: external-${gateway-name}
   namespace: gateway-infra
 spec:
+  # SC-5, SC-5(2)
   gatewayClassName: gke-l7-global-external-managed
   addresses:
     - type: NamedAddress
@@ -27,6 +29,7 @@ spec:
     - name: https
       protocol: HTTPS
       port: 443
+      # SC-8
       tls:
         mode: Terminate
         options:

--- a/solutions/gke/kubernetes/cluster-defaults/gateway/gcpgatewaypolicy.yaml
+++ b/solutions/gke/kubernetes/cluster-defaults/gateway/gcpgatewaypolicy.yaml
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# Assign SSL policy to gateway
+# SC-5, SC-5(2), SC-8 - Assigning  SSL policy to the gateway
 apiVersion: networking.gke.io/v1
 kind: GCPGatewayPolicy
 metadata:
   name: external-gateway-name-policy # kpt-set: external-${gateway-name}-policy
   namespace: gateway-infra
 spec:
+  # SC-5, SC-5(2), SC-8
   default:
     sslPolicy: ssl-policy # kpt-set: ${ssl-policy}
   targetRef:

--- a/solutions/gke/kubernetes/cluster-defaults/gateway/setters.yaml
+++ b/solutions/gke/kubernetes/cluster-defaults/gateway/setters.yaml
@@ -29,8 +29,17 @@ data:
   # Gateway
   ##########################
   #
+  # The name of the gateway resource that is created in the kubernetes/cluster-defaults/gateway package.
+  # customization: required
   gateway-name: sample-gateway
+  #
+  # the ssl-policy that will be applied to the gcpgatewaypolicy
+  # must remain the same as name found in ssl-policies/ssl-policy-tls-1.2.yaml
+  # customization: do not change
   ssl-policy: tls-1-2-computesslpolicy
+  #
+  # the ssl-cert will be the same certificate-name that was created by the configcontroller/gke-defaults/gateway-setup/ssl-certificate
+  # customization: required
   ssl-cert: sample-cert
   #
   ##########################

--- a/solutions/gke/kubernetes/cluster-defaults/network-logging.yaml
+++ b/solutions/gke/kubernetes/cluster-defaults/network-logging.yaml
@@ -1,5 +1,5 @@
 # Per Cluster resource
-# Enables logging for traffic allowed / blocked by Network Policies
+# AU-12, AU-3, AU-3(1) - Enables logging for traffic allowed / blocked by Network Policies
 # More info: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy-logging
 # In future we may want to enable delegate and only log traffic allowed / blocked by specific rules
 kind: NetworkLogging
@@ -7,6 +7,7 @@ apiVersion: networking.gke.io/v1alpha1
 metadata:
   name: default
 spec:
+  # AU-12, AU-3, AU-3(1)
   cluster:
     allow:
       log: true

--- a/solutions/gke/kubernetes/cluster-defaults/securitycontrols.md
+++ b/solutions/gke/kubernetes/cluster-defaults/securitycontrols.md
@@ -3,5 +3,23 @@
 <!-- BEGINNING OF SECURITY CONTROLS LIST -->
 |Security Control|File Name|Resource Name|
 |---|---|---|
+|AU-12|./network-logging.yaml|default|
+|AU-12|./network-logging.yaml|default|
+|AU-3|./network-logging.yaml|default|
+|AU-3|./network-logging.yaml|default|
+|AU-3(1)|./network-logging.yaml|default|
+|AU-3(1)|./network-logging.yaml|default|
+|SC-5|./gateway/gateway-global.yaml|external-gateway-name|
+|SC-5|./gateway/gateway-global.yaml|external-gateway-name|
+|SC-5|./gateway/gcpgatewaypolicy.yaml|external-gateway-name-policy|
+|SC-5|./gateway/gcpgatewaypolicy.yaml|external-gateway-name-policy|
+|SC-5(2)|./gateway/gateway-global.yaml|external-gateway-name|
+|SC-5(2)|./gateway/gateway-global.yaml|external-gateway-name|
+|SC-5(2)|./gateway/gcpgatewaypolicy.yaml|external-gateway-name-policy|
+|SC-5(2)|./gateway/gcpgatewaypolicy.yaml|external-gateway-name-policy|
+|SC-8|./gateway/gateway-global.yaml|external-gateway-name|
+|SC-8|./gateway/gateway-global.yaml|external-gateway-name|
+|SC-8|./gateway/gcpgatewaypolicy.yaml|external-gateway-name-policy|
+|SC-8|./gateway/gcpgatewaypolicy.yaml|external-gateway-name-policy|
 
 <!-- END OF SECURITY CONTROLS LIST -->

--- a/solutions/gke/kubernetes/namespace-defaults/cd/gitops-config-sync.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/cd/gitops-config-sync.yaml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# Root Sync to observe foler csync/tier4/kubernetes/<fleet-id>/deploy/env/<namespace>
+# Root Sync to observe folder csync/tier4/kubernetes/<fleet-id>/deploy/env/<namespace>
+# CM-5(1) - Files are read from the folder and applied to the infrastructure in automated way
 apiVersion: configsync.gke.io/v1beta1
 kind: RootSync
 metadata:

--- a/solutions/gke/kubernetes/namespace-defaults/namespace-sa.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/namespace-sa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# Creates Kuberenetes Service Account to be used by applications deployed in the namespace
+# AC-3(7), AC-3 - Creates Kubernetes Service Account to be used by applications deployed in the namespace
 # Kubernetes Service Account is annotated with the Google Service Account to which it is bound using workload identity.
 apiVersion: v1
 kind: ServiceAccount

--- a/solutions/gke/kubernetes/namespace-defaults/networkpolicy.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/networkpolicy.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# Network Policies
+# AC-4, AC-4(21), SC-7(5), SC-7(9), SC-7(11) - Network Policies to allow or deny ingress and egress traffic to/from namespace
 # Allow ingress within namespace
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -21,6 +21,7 @@ metadata:
   name: allow-ingress-within-namespace
 spec:
   podSelector: {}
+  # AC-4, AC-4(21), SC-7(5), SC-7(9), SC-7(11)
   ingress:
     # From all pods within the same namespace
     - from:
@@ -34,6 +35,7 @@ metadata:
   name: allow-ingress-from-gateway
 spec:
   podSelector: {}
+  # AC-4, AC-4(21), SC-7(5), SC-7(9), SC-7(11)
   ingress:
     # From gateway namespace
     - from:
@@ -49,6 +51,7 @@ metadata:
   name: allow-ingress-from-lb-health-check
 spec:
   podSelector: {}
+  # AC-4, AC-4(21), SC-7(5), SC-7(9), SC-7(11)
   ingress:
     - from:
         - ipBlock:
@@ -71,6 +74,7 @@ metadata:
   name: allow-egress-within-namespace
 spec:
   podSelector: {}
+  # AC-4, AC-4(21), SC-7(5), SC-7(9), SC-7(11)
   egress:
     # To all pods within the same namespace
     - to:
@@ -84,6 +88,7 @@ metadata:
   name: allow-egress-to-metadata-server
 spec:
   podSelector: {}
+  # AC-4, AC-4(21), SC-7(5), SC-7(9), SC-7(11)
   egress:
     # Network policy and Workload Identity
     # For clusters running GKE version 1.21.0-gke.1000 and later, allow egress to 169.254.169.252/32 on port 988
@@ -120,6 +125,7 @@ metadata:
   name: allow-egrees-to-gcp-api
 spec:
   podSelector: {}
+  # AC-4, AC-4(21), SC-7(5), SC-7(9), SC-7(11)
   egress:
     - to:
         - ipBlock:

--- a/solutions/gke/kubernetes/namespace-defaults/rolebinding-httproute-admin.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/rolebinding-httproute-admin.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# Role to manage routes in the workload namespace
+# AC-3(7) - Role to manage routes in the workload namespace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -23,6 +23,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+    # AC-3(7)
     verbs:
       - get
       - list
@@ -38,6 +39,7 @@ kind: RoleBinding
 metadata:
   name: httproute-admin-rolebinding
   namespace: workload-name # kpt-set: ${workload-name}
+# AC-3(7)
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/solutions/gke/kubernetes/namespace-defaults/rolebinding-team-view.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/rolebinding-team-view.yaml
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# Grant view access to user or group
+# AC-3(7) - Grant view access to user or group
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: team-view-rolebinding
   namespace: workload-name # kpt-set: ${workload-name}
+# AC-3(7)
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/solutions/gke/kubernetes/namespace-defaults/securitycontrols.md
+++ b/solutions/gke/kubernetes/namespace-defaults/securitycontrols.md
@@ -3,5 +3,47 @@
 <!-- BEGINNING OF SECURITY CONTROLS LIST -->
 |Security Control|File Name|Resource Name|
 |---|---|---|
+|AC-3|./namespace-sa.yaml|workload-name-sa|
+|AC-3(7)|./namespace-sa.yaml|workload-name-sa|
+|AC-3(7)|./rolebinding-httproute-admin.yaml|httproute-admin-role|
+|AC-3(7)|./rolebinding-httproute-admin.yaml|httproute-admin-role|
+|AC-3(7)|./rolebinding-httproute-admin.yaml|httproute-admin-rolebinding|
+|AC-3(7)|./rolebinding-team-view.yaml|team-view-rolebinding|
+|AC-3(7)|./rolebinding-team-view.yaml|team-view-rolebinding|
+|AC-4|./networkpolicy.yaml|allow-egrees-to-gcp-api|
+|AC-4|./networkpolicy.yaml|allow-egress-to-metadata-server|
+|AC-4|./networkpolicy.yaml|allow-egress-within-namespace|
+|AC-4|./networkpolicy.yaml|allow-ingress-from-gateway|
+|AC-4|./networkpolicy.yaml|allow-ingress-from-lb-health-check|
+|AC-4|./networkpolicy.yaml|allow-ingress-within-namespace|
+|AC-4|./networkpolicy.yaml|allow-ingress-within-namespace|
+|AC-4(21)|./networkpolicy.yaml|allow-egrees-to-gcp-api|
+|AC-4(21)|./networkpolicy.yaml|allow-egress-to-metadata-server|
+|AC-4(21)|./networkpolicy.yaml|allow-egress-within-namespace|
+|AC-4(21)|./networkpolicy.yaml|allow-ingress-from-gateway|
+|AC-4(21)|./networkpolicy.yaml|allow-ingress-from-lb-health-check|
+|AC-4(21)|./networkpolicy.yaml|allow-ingress-within-namespace|
+|AC-4(21)|./networkpolicy.yaml|allow-ingress-within-namespace|
+|SC-7(11)|./networkpolicy.yaml|allow-egrees-to-gcp-api|
+|SC-7(11)|./networkpolicy.yaml|allow-egress-to-metadata-server|
+|SC-7(11)|./networkpolicy.yaml|allow-egress-within-namespace|
+|SC-7(11)|./networkpolicy.yaml|allow-ingress-from-gateway|
+|SC-7(11)|./networkpolicy.yaml|allow-ingress-from-lb-health-check|
+|SC-7(11)|./networkpolicy.yaml|allow-ingress-within-namespace|
+|SC-7(11)|./networkpolicy.yaml|allow-ingress-within-namespace|
+|SC-7(5)|./networkpolicy.yaml|allow-egrees-to-gcp-api|
+|SC-7(5)|./networkpolicy.yaml|allow-egress-to-metadata-server|
+|SC-7(5)|./networkpolicy.yaml|allow-egress-within-namespace|
+|SC-7(5)|./networkpolicy.yaml|allow-ingress-from-gateway|
+|SC-7(5)|./networkpolicy.yaml|allow-ingress-from-lb-health-check|
+|SC-7(5)|./networkpolicy.yaml|allow-ingress-within-namespace|
+|SC-7(5)|./networkpolicy.yaml|allow-ingress-within-namespace|
+|SC-7(9)|./networkpolicy.yaml|allow-egrees-to-gcp-api|
+|SC-7(9)|./networkpolicy.yaml|allow-egress-to-metadata-server|
+|SC-7(9)|./networkpolicy.yaml|allow-egress-within-namespace|
+|SC-7(9)|./networkpolicy.yaml|allow-ingress-from-gateway|
+|SC-7(9)|./networkpolicy.yaml|allow-ingress-from-lb-health-check|
+|SC-7(9)|./networkpolicy.yaml|allow-ingress-within-namespace|
+|SC-7(9)|./networkpolicy.yaml|allow-ingress-within-namespace|
 
 <!-- END OF SECURITY CONTROLS LIST -->

--- a/solutions/gke/kubernetes/namespace-defaults/setters.yaml
+++ b/solutions/gke/kubernetes/namespace-defaults/setters.yaml
@@ -30,6 +30,7 @@ data:
   ##########################
   #
   # project-id created by the client-project-setup package
+  # customization: required
   project-id: project-12345
   #
   ##########################
@@ -37,27 +38,42 @@ data:
   ##########################
   #
   # Name for the client, lowercase only
+  # customization: required
   client-name: 'client1'
   #
   ##########################
   # Application
   ##########################
   #
-  # the name of the workload, lowercase only
+  # the name of the workload that was created in the configcontroller/gke-workload-identity package
+  # lowercase only, max 27 characters
+  # customization: required
   workload-name: sample-workload
+  #
   # user or group to grant view role on workload namespace
+  # customization: required
   workload-view: 'group:client1@example.com'
   #
   ##########################
   # Config Sync
   ##########################
+  #
+  # Used for the tier4 root sync with a git repo (GitHub, Azure DevOps, etc.)
+  # The repo stores the manifests for the tier4 kubernetes resources to be deployed within this namespace
+  # To disable this option, delete the file cd/gitops-config-sync.yaml
+  #
   # the git repo URL, for example
   # https://github.com/GITHUB-ORG/REPO-NAME
   # https://AZDO-ORG@dev.azure.com/AZDO-ORG/AZDO-PROJECT/_git/REPO-NAME
+  # customization: required
   repo-url: git-repo-to-observe
+  #
   # the branch to check out (usually main)
+  # customization: optional
   repo-branch: main
+  #
   # the directory to observe for YAML manifests
+  # customization: required
   repo-dir: csync/tier4/kubernetes/<fleet-id>/deploy/env/<namespace>
   #
   ##########################


### PR DESCRIPTION
cleanup setters / security controls comments (issue #617) for these packages:

- solutions/gke/configconnector/gke-cluster-autopilot/
- solutions/gke/configconnector/gke-defaults/
- solutions/gke/configconnector/gke-workload-identity/
- solutions/gke/kubernetes/cluster-defaults/
- solutions/gke/kubernetes/namespace-defaults/

credits to @anoopsidhu-ssc @CraigBaltzer @seanwilkens-ssc @davelanglois-ssc