### PR TITLE
feat: enable logging on cloud nat resources

### DIFF
--- a/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/nat.yaml
+++ b/solutions/client-landing-zone/client-folder/standard/applications-infrastructure/host-project/network/nat.yaml
@@ -28,6 +28,9 @@ spec:
   routerRef:
     name: host-project-id-nane1-router # kpt-set: ${host-project-id}-nane1-router
   sourceSubnetworkIpRangesToNat: ALL_SUBNETWORKS_ALL_IP_RANGES
+  logConfig:
+    enable: true
+    filter: ALL
 ---
 # Cloud Router northamerica-northeast1
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
@@ -61,6 +64,9 @@ spec:
   routerRef:
     name: host-project-id-nane2-router # kpt-set: ${host-project-id}-nane2-router
   sourceSubnetworkIpRangesToNat: ALL_SUBNETWORKS_ALL_IP_RANGES
+  logConfig:
+    enable: true
+    filter: ALL
 ---
 # Cloud Router northamerica-northeast2
 apiVersion: compute.cnrm.cloud.google.com/v1beta1


### PR DESCRIPTION
Closes #637

Updating client-landing-zone package.

Enables logging for Cloud NAT
https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computerouternat

Spec added (ALL=Translation and errors):
```yaml
logConfig:
  enable: true
  filter: ALL
```