### PR TITLE
moved services to use projectref instead of annotation

### DIFF
--- a/solutions/core-landing-zone/lz-folder/services-infrastructure/dns-project/services.yaml
+++ b/solutions/core-landing-zone/lz-folder/services-infrastructure/dns-project/services.yaml
@@ -24,3 +24,5 @@ metadata:
     config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/dns-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${dns-project-id}
 spec:
   resourceID: dns.googleapis.com
+  projectRef:
+    external: dns-project-id # kpt-set: ${dns-project-id}

--- a/solutions/core-landing-zone/mgmt-project/services.yaml
+++ b/solutions/core-landing-zone/mgmt-project/services.yaml
@@ -21,9 +21,10 @@ metadata:
   annotations:
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
-    cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceID: cloudbilling.googleapis.com
+  projectRef:
+    external: management-project-id # kpt-set: ${management-project-id}
 ---
 # Cloudresourcemanager API
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
@@ -34,9 +35,10 @@ metadata:
   annotations:
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
-    cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceID: cloudresourcemanager.googleapis.com
+  projectRef:
+    external: management-project-id # kpt-set: ${management-project-id}
 ---
 # Serviceusage API
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
@@ -47,9 +49,10 @@ metadata:
   annotations:
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
-    cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceID: serviceusage.googleapis.com
+  projectRef:
+    external: management-project-id # kpt-set: ${management-project-id}
 ---
 # Access Context Manager API
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
@@ -60,6 +63,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
-    cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceID: accesscontextmanager.googleapis.com
+  projectRef:
+    external: management-project-id # kpt-set: ${management-project-id}


### PR DESCRIPTION
This PR fixes updates the service resources in the core-landing-zone package to use `projectRef` when identifying the project instead of the `cnrm.cloud.google.com/project-id` annotation and brings it inline with current resource organization guidelines. https://cloud.google.com/config-connector/docs/how-to/organizing-resources/overview

More to follow for additional packages.