### PR TITLE
fix: IDS, adding firewall rule to PSA and documentation

### DIFF
--- a/solutions/ids/README.md
+++ b/solutions/ids/README.md
@@ -33,17 +33,18 @@ This package needs to be deployed in multiple steps because the `ComputePacketMi
 
 ## Setters
 
-|            Name             |                             Value                              | Type | Count |
-|-----------------------------|----------------------------------------------------------------|------|-------|
-| address                     | 10.254.0.0                                                     | str  |     1 |
-| client-name                 | client1                                                        | str  |    12 |
-| endpoint-name               | endpoint-name                                                  | str  |     5 |
-| host-project-id             | net-host-project-12345                                         | str  |    21 |
-| host-project-vpc            | projects/<host-project-id>/global/networks/global-standard-vpc | str  |     2 |
-| ids-endpoint-forwardingrule | ids-endpoint-forwardingrule                                    | str  |     1 |
-| region                      | region                                                         | str  |     1 |
-| severity                    | severity                                                       | str  |     1 |
-| zone                        | zone                                                           | str  |     2 |
+|            Name             |                             Value                              | Type  | Count |
+|-----------------------------|----------------------------------------------------------------|-------|-------|
+| address                     | 10.254.0.0                                                     | str   |     1 |
+| client-name                 | client1                                                        | str   |    14 |
+| endpoint-name               | endpoint-name                                                  | str   |     5 |
+| firewall-address            | [10.254.0.0/16]                                                | array |     1 |
+| host-project-id             | net-host-project-12345                                         | str   |    25 |
+| host-project-vpc            | projects/<host-project-id>/global/networks/global-standard-vpc | str   |     2 |
+| ids-endpoint-forwardingrule | ids-endpoint-forwardingrule                                    | str   |     1 |
+| region                      | region                                                         | str   |     1 |
+| severity                    | severity                                                       | str   |     1 |
+| zone                        | zone                                                           | str   |     2 |
 
 ## Sub-packages
 
@@ -54,6 +55,7 @@ This package needs to be deployed in multiple steps because the `ComputePacketMi
 |     File      |                   APIVersion                    |            Kind             |                        Name                         |       Namespace        |
 |---------------|-------------------------------------------------|-----------------------------|-----------------------------------------------------|------------------------|
 | address.yaml  | compute.cnrm.cloud.google.com/v1beta1           | ComputeAddress              | host-project-id-standard-google-managed-services-ip | client-name-networking |
+| firewall.yaml | compute.cnrm.cloud.google.com/v1beta1           | ComputeFirewall             | host-project-id-standard-egress-allow-psa-fwr       | client-name-networking |
 | peering.yaml  | servicenetworking.cnrm.cloud.google.com/v1beta1 | ServiceNetworkingConnection | host-project-id-standard-to-googlemanaged-peer      | client-name-networking |
 | services.yaml | serviceusage.cnrm.cloud.google.com/v1beta1      | Service                     | host-project-id-ids                                 | client-name-projects   |
 | services.yaml | serviceusage.cnrm.cloud.google.com/v1beta1      | Service                     | host-project-id-servicenetworking                   | client-name-projects   |
@@ -61,6 +63,7 @@ This package needs to be deployed in multiple steps because the `ComputePacketMi
 ## Resource References
 
 - [ComputeAddress](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeaddress)
+- [ComputeFirewall](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computefirewall)
 - [ServiceNetworkingConnection](https://cloud.google.com/config-connector/docs/reference/resource-docs/servicenetworking/servicenetworkingconnection)
 - [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
 

--- a/solutions/ids/endpoint/endpoint.yaml
+++ b/solutions/ids/endpoint/endpoint.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# Cloud IDS endpoint
+# AC-17(1), SC-7(9), SC-18(1), SI-3(2), SI-3(4), SI-3(7), SI-4(4), SI-4(5), SI-4(7) - Defining Cloud IDS endpoint to receive mirrored traffic that performs threat detection and analysis
 # Warning! requires the alpha resource loaded in the config controller
 # https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/crds/cloudids_v1alpha1_cloudidsendpoint.yaml
 apiVersion: cloudids.cnrm.cloud.google.com/v1alpha1

--- a/solutions/ids/endpoint/mirroring.yaml
+++ b/solutions/ids/endpoint/mirroring.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# Packet mirroring policy
+# AC-17(1), SC-7(9), SC-18(1), SI-3(2), SI-3(4), SI-3(7), SI-4(4), SI-4(5), SI-4(7) - Define Packet mirroring policy that uses Google Cloud Packet Mirroring which creates a copy of traffic in our VPC. This policy send mirrored traffic to the endpoint created for inspection
 # 1 per vpc and per region minimum
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputePacketMirroring

--- a/solutions/ids/endpoint/setters.yaml
+++ b/solutions/ids/endpoint/setters.yaml
@@ -32,13 +32,16 @@ data:
   # a name to identify this endpoint
   # customization: optional for first package
   endpoint-name: endpoint1
+  #
   # the zone for the endpoint (must be within region of mirroring policy below)
   # customization: optional
   zone: northamerica-northeast1-a
+  #
   # the minimum alert severity level that is reported by the
   # endpoint. Possible values: ["INFORMATIONAL", "LOW", "MEDIUM", "HIGH", "CRITICAL"]
   # customization: optional
   severity: LOW
+  #
   # Configuration for threat IDs excluded from generating alerts. Limit: 99 IDs
   # Warning: uncomment this field if required. It is not applied using apply-setters but by starlark-update-endpoint-mirroring
   # customization: required if enabled
@@ -53,11 +56,13 @@ data:
   # the region for the mirroring policy
   # customization: optional
   region: northamerica-northeast1
+  #
   # The endpointForwardingRule value from the IDS endpoint.
   # You can obtain this value once the endpoint has been deployed using the command below.
   # gcloud ids endpoints describe <endpoint-name> --zone <zone> --project <host-project-id>
   # customization: required
   ids-endpoint-forwardingrule: 'https://www.googleapis.com/compute/v1/projects/<uid>/regions/<region>/forwardingRules/<uid>'
+  #
   # mirroredResources specifies a set of mirrored VM instances, subnetworks
   # and/or tags for which traffic from/to all VM instances will be mirrored
   # Warning ! this field is not applied using apply-setters but by starlark-update-endpoint-mirroring
@@ -75,10 +80,11 @@ data:
           namespace: string
     tags:
       - tag-one
+  #
   # Filter for mirrored traffic.
   # Refer to the resources's spec to identify the possible configuration for this object.
   # Warning ! this field is not applied using apply-setters but by starlark-update-endpoint-mirroring
-  # customization: optionnal.
+  # customization: optional.
   filter:
     direction: BOTH
   #
@@ -87,10 +93,15 @@ data:
   ##########################
   #
   # Name for the client, lowercase only
+  # customization: required
   client-name: client1
+  #
   # the network host project id that is created by the client-landing-zone package
+  # customization: required
   host-project-id: net-host-project-12345
+  #
   # full URL(selfLink) of the VPC network that is connected to the IDS endpoint. This VPC exist in the host project.
+  # customization: required
   host-project-vpc: projects/<host-project-id>/global/networks/global-standard-vpc
   #
   ##########################

--- a/solutions/ids/firewall.yaml
+++ b/solutions/ids/firewall.yaml
@@ -12,22 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# IP reservation
-# AC-17(1), SC-7(9), SC-18(1), SI-3(2), SI-3(4), SI-3(7), SI-4(4), SI-4(5), SI-4(7) - Private service access for Google managed services to connect virtual machines in VPC to the Google managed peered virtual machines. Cloud IDS endpoints also use the same private service access
+# Egress allow traffic to Private service access for Google managed services. Logging is disabled as this is used mainly for Intrusion Detection System.
+# AC-3(9), AC-4, AC-4(21), SC-7(5), SC-7(8), SC-7(9), SC-7(11) - All connections to or from virtual machine instances are allowed/denied via firewall rules configured in shared VPC network within host project or firewall policies in parent folders based on least-privilege principle. Each firewall rule applies to incoming(ingress) or outgoing(egress) connections, not both.
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeAddress
+kind: ComputeFirewall
 metadata:
-  name: host-project-id-standard-google-managed-services-ip # kpt-set: ${host-project-id}-standard-google-managed-services-ip
+  name: host-project-id-standard-egress-allow-psa-fwr # kpt-set: ${host-project-id}-standard-egress-allow-psa-fwr
   namespace: client-name-networking # kpt-set: ${client-name}-networking
   annotations:
     cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
     config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/client-name-networking/ComputeNetwork/host-project-id-global-standard-vpc # kpt-set: compute.cnrm.cloud.google.com/namespaces/${client-name}-networking/ComputeNetwork/${host-project-id}-global-standard-vpc
 spec:
-  resourceID: standard-google-managed-services-ip
-  address: address # kpt-set: ${address}
-  prefixLength: 16
-  addressType: INTERNAL
-  location: global
-  purpose: VPC_PEERING
+  resourceID: standard-egress-allow-psa-fwr
+  description: "Egress allow traffic to Private service access for Google managed services"
+  direction: EGRESS
+  priority: 1000
+  allow:
+    - protocol: all
+  destinationRanges: # kpt-set: ${firewall-address}
+    - firewall-address
+  # AC-3(9), AC-4, AC-4(21), SC-7(5), SC-7(8), SC-7(9), SC-7(11)
   networkRef:
     name: host-project-id-global-standard-vpc # kpt-set: ${host-project-id}-global-standard-vpc

--- a/solutions/ids/peering.yaml
+++ b/solutions/ids/peering.yaml
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# VPC Peering
-# Google Managed Services
+# AC-17(1), SC-7(9), SC-18(1), SI-3(2), SI-3(4), SI-3(7), SI-4(4), SI-4(5), SI-4(7) - Establish VPC Peering between vpc network and Google Managed Services
 apiVersion: servicenetworking.cnrm.cloud.google.com/v1beta1
 kind: ServiceNetworkingConnection
 metadata:

--- a/solutions/ids/securitycontrols.md
+++ b/solutions/ids/securitycontrols.md
@@ -3,5 +3,34 @@
 <!-- BEGINNING OF SECURITY CONTROLS LIST -->
 |Security Control|File Name|Resource Name|
 |---|---|---|
+|AC-17(1)|./address.yaml|host-project-id-standard-google-managed-services-ip|
+|AC-17(1)|./endpoint/endpoint.yaml|host-project-id--endpoint-name-ids|
+|AC-17(1)|./endpoint/mirroring.yaml|host-project-id--endpoint-name-mirror|
+|AC-17(1)|./peering.yaml|host-project-id-standard-to-googlemanaged-peer|
+|AC-17(1)|./services.yaml|host-project-id-ids|
+|AC-3(9)|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|AC-3(9)|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|AC-4|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|AC-4|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|AC-4(21)|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|AC-4(21)|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|SC-18(1)|./address.yaml|host-project-id-standard-google-managed-services-ip|
+|SC-18(1)|./endpoint/endpoint.yaml|host-project-id--endpoint-name-ids|
+|SC-18(1)|./endpoint/mirroring.yaml|host-project-id--endpoint-name-mirror|
+|SC-18(1)|./peering.yaml|host-project-id-standard-to-googlemanaged-peer|
+|SC-18(1)|./services.yaml|host-project-id-ids|
+|SC-7(11)|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|SC-7(11)|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|SC-7(5)|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|SC-7(5)|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|SC-7(8)|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|SC-7(8)|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|SC-7(9)|./address.yaml|host-project-id-standard-google-managed-services-ip|
+|SC-7(9)|./endpoint/endpoint.yaml|host-project-id--endpoint-name-ids|
+|SC-7(9)|./endpoint/mirroring.yaml|host-project-id--endpoint-name-mirror|
+|SC-7(9)|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|SC-7(9)|./firewall.yaml|host-project-id-standard-egress-allow-psa-fwr|
+|SC-7(9)|./peering.yaml|host-project-id-standard-to-googlemanaged-peer|
+|SC-7(9)|./services.yaml|host-project-id-ids|
 
 <!-- END OF SECURITY CONTROLS LIST -->

--- a/solutions/ids/services.yaml
+++ b/solutions/ids/services.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# Cloud IDS API
+# AC-17(1), SC-7(9), SC-18(1), SI-3(2), SI-3(4), SI-3(7), SI-4(4), SI-4(5), SI-4(7) - Enable Cloud IDS APIs in host project that contains shared vpc network 
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:

--- a/solutions/ids/services.yaml
+++ b/solutions/ids/services.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #########
-# AC-17(1), SC-7(9), SC-18(1), SI-3(2), SI-3(4), SI-3(7), SI-4(4), SI-4(5), SI-4(7) - Enable Cloud IDS APIs in host project that contains shared vpc network 
+# AC-17(1), SC-7(9), SC-18(1), SI-3(2), SI-3(4), SI-3(7), SI-4(4), SI-4(5), SI-4(7) - Enable Cloud IDS APIs in host project that contains shared vpc network
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:

--- a/solutions/ids/services.yaml
+++ b/solutions/ids/services.yaml
@@ -20,10 +20,11 @@ metadata:
   namespace: client-name-projects # kpt-set: ${client-name}-projects
   annotations:
     cnrm.cloud.google.com/disable-on-destroy: "false"
-    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
     config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/host-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${host-project-id}
 spec:
   resourceID: ids.googleapis.com
+  projectRef:
+    external: host-project-id # kpt-set: ${host-project-id}
 ---
 # Service Networking API
 # required for private service access and cloud IDS
@@ -35,7 +36,8 @@ metadata:
   namespace: client-name-projects # kpt-set: ${client-name}-projects
   annotations:
     cnrm.cloud.google.com/disable-on-destroy: "false"
-    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
     config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client-name-projects/Project/host-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${host-project-id}
 spec:
   resourceID: servicenetworking.googleapis.com
+  projectRef:
+    external: host-project-id # kpt-set: ${host-project-id}

--- a/solutions/ids/setters.yaml
+++ b/solutions/ids/setters.yaml
@@ -40,6 +40,7 @@ data:
   # the network host project id that is created by the client-landing-zone package
   # customization: required
   host-project-id: net-host-project-12345
+  #
   # full URL(selfLink) of the VPC network that is connected to the IDS endpoint. This VPC exist in the host project.
   # customization: required
   host-project-vpc: projects/<host-project-id>/global/networks/global-standard-vpc
@@ -48,9 +49,14 @@ data:
   # Private service access
   ##########################
   #
-  # IP reservation for Private service access to Google managed services. The prefix lenght is a /16.
+  # IP reservation for Private service access to Google managed services. The prefix length is a /16.
   # customization: optional
   address: 10.254.0.0
+  #
+  # the CIDR range for the firewall rule that allows egress to Private service access. Include the prefix /16
+  # customization: optional
+  firewall-address: |
+    - 10.254.0.0/16
   #
   ##########################
   # End of Configurations


### PR DESCRIPTION
- improving documentation and security controls
- adding a firewall rule to ensure egress traffic towards private service access is allowed.

**_ADDITIONAL CONTEXT_**: when you deploy an IDS endpoint, a forwarding rule is created within the IP range assigned for private service access. To ensure IDS works, all GCE and GKE have to be able to send traffic to this ip. Traffic is replicated to this ip because of the packet mirroring policy that is attached to all resources specified by the filter.

closes #617 