### PR TITLE
fix: GKE-CLUSTER-AUTOPILOT changing subnet and adding ids network tag

### DIFF
--- a/solutions/gke/configconnector/gke-cluster-autopilot/Kptfile
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/Kptfile
@@ -61,3 +61,5 @@ pipeline:
   mutators:
     - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml
+    - image: gcr.io/kpt-fn/starlark:v0.4.3
+      configPath: starlark-update-containercluster.yaml

--- a/solutions/gke/configconnector/gke-cluster-autopilot/README.md
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/README.md
@@ -73,6 +73,7 @@ To fix this, you update the `root-sync` resource to include the override section
 | masterIpv4CidrBlock             | 192.168.0.0/28                                       | str   |     1 |
 | masterIpv4Range                 | ["192.168.0.0/28"]                                   | array |     0 |
 | networktags                     |                                                      | str   |     0 |
+| networktags-enabled             | false                                                | str   |     0 |
 | podIpv4Range                    | ["172.16.0.0/23"]                                    | array |     1 |
 | primaryIpv4Range                | ["10.1.32.0/24"]                                     | array |     3 |
 | project-id                      | project-12345                                        | str   |    51 |

--- a/solutions/gke/configconnector/gke-cluster-autopilot/README.md
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/README.md
@@ -70,15 +70,16 @@ To fix this, you update the `root-sync` resource to include the override section
 | host-project-vpc                | host-project-vpc                                     | str   |     2 |
 | location                        | northamerica-northeast1                              | str   |     5 |
 | master-authorized-networks-cidr | [cidrBlock: 10.1.1.5/32displayName: gke-admin-proxy] | array |     1 |
-| masterIpv4CidrBlock             | 172.16.0.0/28                                        | str   |     1 |
-| masterIpv4Range                 | ["172.16.0.0/28"]                                    | array |     0 |
-| podIpv4Range                    | ["240.1.0.0/21"]                                     | array |     1 |
+| masterIpv4CidrBlock             | 192.168.0.0/28                                       | str   |     1 |
+| masterIpv4Range                 | ["192.168.0.0/28"]                                   | array |     0 |
+| networktags                     |                                                      | str   |     0 |
+| podIpv4Range                    | ["172.16.0.0/23"]                                    | array |     1 |
 | primaryIpv4Range                | ["10.1.32.0/24"]                                     | array |     3 |
 | project-id                      | project-12345                                        | str   |    51 |
 | repo-branch                     | main                                                 | str   |     1 |
 | repo-dir                        | csync/tier3/kubernetes/<fleet-id>/deploy/<env>       | str   |     1 |
 | repo-url                        | tier34-repo-to-observe                               | str   |     1 |
-| subnet-pod-cidr                 | 240.1.0.0/21                                         | str   |     1 |
+| subnet-pod-cidr                 | 172.16.0.0/23                                        | str   |     1 |
 | subnet-primary-cidr             | 10.1.32.0/24                                         | str   |     1 |
 | subnet-services-cidr            | 10.1.33.0/24                                         | str   |     1 |
 

--- a/solutions/gke/configconnector/gke-cluster-autopilot/gke.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/gke.yaml
@@ -33,11 +33,15 @@ spec:
     autoProvisioningDefaults:
       serviceAccountRef:
         name: cluster-name-sa # kpt-set: ${cluster-name}-sa
-  description: GKE Autopilot Cluster
   # SC-28, SC-28(1)
   databaseEncryption:
     keyName: projects/project-id/locations/northamerica-northeast1/keyRings/cluster-name-kmskeyring/cryptoKeys/cluster-name-etcd-key # kpt-set: projects/${project-id}/locations/${location}/keyRings/${cluster-name}-kmskeyring/cryptoKeys/${cluster-name}-etcd-key
     state: ENCRYPTED
+  # defaultMaxPodsPerNode is not working with GKE autopilot.
+  # defaultMaxPodsPerNode: 16
+  defaultSnatStatus:
+    disabled: true
+  description: GKE Autopilot Cluster
   enableAutopilot: true
   # binaryAuthorization:
   #   evaluationMode: PROJECT_SINGLETON_POLICY_ENFORCE
@@ -71,6 +75,11 @@ spec:
     name: host-project-vpc # kpt-set: ${host-project-vpc}
     namespace: client-name-networking # kpt-set: ${client-name}-networking
   networkingMode: VPC_NATIVE
+  nodePoolAutoConfig:
+    # network tags are defined in setters.yaml and updated by the starlark function starlark-update-containercluster.yaml
+    networkTags:
+      tags:
+        - ids
   notificationConfig:
     pubsub:
       enabled: true
@@ -82,7 +91,9 @@ spec:
   privateClusterConfig:
     enablePrivateEndpoint: true
     enablePrivateNodes: true
-    masterIpv4CidrBlock: 172.16.0.0/28 # kpt-set: ${masterIpv4CidrBlock}
+    masterIpv4CidrBlock: 192.168.0.0/28 # kpt-set: ${masterIpv4CidrBlock}
+    masterGlobalAccessConfig:
+      enabled: true
   releaseChannel:
     channel: REGULAR
   subnetworkRef:

--- a/solutions/gke/configconnector/gke-cluster-autopilot/host-project/subnet.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/host-project/subnet.yaml
@@ -35,7 +35,7 @@ spec:
   secondaryIpRange:
     - ipCidrRange: 10.1.33.0/24 # kpt-set: ${subnet-services-cidr}
       rangeName: servicesrange
-    - ipCidrRange: 240.1.0.0/21 # kpt-set: ${subnet-pod-cidr}
+    - ipCidrRange: 172.16.0.0/23 # kpt-set: ${subnet-pod-cidr}
       rangeName: podrange
   region: northamerica-northeast1 # kpt-set: ${location}
   description: GKE Subnet

--- a/solutions/gke/configconnector/gke-cluster-autopilot/setters.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/setters.yaml
@@ -119,10 +119,11 @@ data:
   # The "ids" tag is the recommended approach to ensure that the traffic reaching the GKE clusters is inspected by Cloud IDS.
   # Furthermore, you would need to have that "ids" tag listed under the mirroredresources of the packet mirroring policy.
   # See ids package for more details.
-  # Warning: uncomment this field if required. It is not applied using apply-setters but by starlark-update-containercluster
-  # customization: optional if enabled.
-  # networktags:
-  #   - ids
+  # Warning: It is not applied using apply-setters but by starlark-update-containercluster
+  # customization: optional if networktags-enabled is set to true.
+  networktags-enabled: false
+  networktags:
+    - ids
   #
   ##########################
   # Config Sync

--- a/solutions/gke/configconnector/gke-cluster-autopilot/setters.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/setters.yaml
@@ -70,12 +70,12 @@ data:
   # the master control plane cidr for kind ContainerCluster
   # Must be unique within the VPC. Looking at the VPC's routing table can help determine this values
   # customization: optional
-  masterIpv4CidrBlock: 172.16.0.0/28
+  masterIpv4CidrBlock: 192.168.0.0/28
   #
   # the master control plane range for kind ComputeFirewall (same as masterIpv4CidrBlock but using list)
   # customization: optional
   masterIpv4Range: |
-    - "172.16.0.0/28"
+    - "192.168.0.0/28"
   #
   # the master authorized networks cidr - gke admin proxy ip
   # customization: required
@@ -83,22 +83,30 @@ data:
     - cidrBlock: 10.1.1.5/32
       displayName: gke-admin-proxy
   #
-  # subnet IP ranges
-  # Must be unique within the VPC. Looking at the VPC's routing table can help determine these values
+  # subnet primary IP range
+  # Must be unique within the VPC. Looking at the VPC's routing table can help determine this value
   # customization: optional
   subnet-primary-cidr: 10.1.32.0/24
-  subnet-services-cidr: 10.1.33.0/24
-  subnet-pod-cidr: 240.1.0.0/21
   #
-  # the pod range for kind ComputeFirewall (same as subnet-pod-cidr but using list)
-  # customization: optional
-  podIpv4Range: |
-    - "240.1.0.0/21"
-  #
-  # the primary range for kind ComputeFirewall (same as subnet-primary-cidr but using list)
+  # the subnet primary range for kind ComputeFirewall (same as subnet-primary-cidr but using list)
   # customization: optional
   primaryIpv4Range: |
     - "10.1.32.0/24"
+  #
+  # subnet secondary IP range for services
+  # Must be unique within the VPC. Looking at the VPC's routing table can help determine this value
+  # customization: optional
+  subnet-services-cidr: 10.1.33.0/24
+  #
+  # subnet secondary IP range for pods
+  # Must be unique within the VPC. Looking at the VPC's routing table can help determine this value
+  # customization: optional
+  subnet-pod-cidr: 172.16.0.0/23
+  #
+  # the subnet secondary IP range for pods for kind ComputeFirewall (same as subnet-pod-cidr but using list)
+  # customization: optional
+  podIpv4Range: |
+    - "172.16.0.0/23"
   #
   # firewall policies priority, this cannot overlap with any existing policy id
   # can verify by checking the firewall policies for the host project
@@ -106,6 +114,15 @@ data:
   gke-to-azdo-priority: 2000
   gke-to-github-priority: 2001
   gke-to-docker-priority: 2002
+  #
+  # network tags to be assigned to GKE nodes
+  # The "ids" tag is the recommended approach to ensure that the traffic reaching the GKE clusters is inspected by Cloud IDS.
+  # Furthermore, you would need to have that "ids" tag listed under the mirroredresources of the packet mirroring policy.
+  # See ids package for more details.
+  # Warning: uncomment this field if required. It is not applied using apply-setters but by starlark-update-containercluster
+  # customization: optional if enabled.
+  # networktags:
+  #   - ids
   #
   ##########################
   # Config Sync

--- a/solutions/gke/configconnector/gke-cluster-autopilot/starlark-update-containercluster.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/starlark-update-containercluster.yaml
@@ -14,11 +14,13 @@ source: |
   # extract values from setters
   for resource in ctx.resource_list["items"]:
     if resource["metadata"]["name"] in ["setters"]:
-      # extract setters for ContainerCluster
-      if "networktags" in resource["data"]:
-        print("--networktags enabled")
-        networktags_enabled = True
-        networktags = resource["data"]["networktags"]
+      # check if networktags-enabled exist
+      if "networktags-enabled" in resource["data"]:
+        # check if networkstags-enabled is set to true
+        if resource["data"]["networktags-enabled"]:
+          print("--networktags enabled")
+          networktags_enabled = True
+          networktags = resource["data"]["networktags"]
   # search for resources to update
   for resource in ctx.resource_list["items"]:
     print(resource["kind"])

--- a/solutions/gke/configconnector/gke-cluster-autopilot/starlark-update-containercluster.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/starlark-update-containercluster.yaml
@@ -1,0 +1,33 @@
+#
+# This script finds ContainerCluster resources and update the object fields spec.nodePoolAutoConfig.networkTags.tags with the value defined in setters.yaml
+#
+# This script is required because we want to dynamically add a bloc to the ContainerCluster based on the configuration within the setters.yaml
+#
+apiVersion: fn.kpt.dev/v1alpha1
+kind: StarlarkRun
+metadata:
+  name: update-container-cluster
+  annotations:
+    config.kubernetes.io/local-config: "true"
+source: |
+  networktags_enabled = False
+  # extract values from setters
+  for resource in ctx.resource_list["items"]:
+    if resource["metadata"]["name"] in ["setters"]:
+      # extract setters for ContainerCluster
+      if "networktags" in resource["data"]:
+        print("--networktags enabled")
+        networktags_enabled = True
+        networktags = resource["data"]["networktags"]
+  # search for resources to update
+  for resource in ctx.resource_list["items"]:
+    print(resource["kind"])
+    # if resources kind matches ContainerCluster
+    if resource["kind"] in ["ContainerCluster"]:
+      print("--found one ContainerCluster!")
+      if networktags_enabled:
+        print("--networktags is enabled! updating networktags")
+        resource["spec"]["nodePoolAutoConfig"]["networkTags"]["tags"] = networktags
+      else:
+        print("--networktags is disabled! removing nodePoolAutoConfig")
+        resource["spec"].pop("nodePoolAutoConfig")


### PR DESCRIPTION
- changing default ip ranges for pods to use `172.16.0.0/23` by default instead of RFC5735
- changing default ip ranges for control plane to `192.168.0.0/28`
- disabling SNAT to ensure full VPC_NATIVE cluster
- enabling control plane global access to allow connectivity from subnets in any region
- adding network tags support to ease IDS inspection
- adding starlark function to simplify network tags enablement

closes #652 