### PR TITLE
fix: modify logging project data access config

### DIFF
--- a/solutions/core-landing-zone/lz-folder/audits/logging-project/project-iam.yaml
+++ b/solutions/core-landing-zone/lz-folder/audits/logging-project/project-iam.yaml
@@ -117,9 +117,7 @@ spec:
   service: allServices
   # AU-9, AC-3
   auditLogConfigs:
-    - logType: ADMIN_READ
     - logType: DATA_READ
-    - logType: DATA_WRITE
   resourceRef:
     kind: Project
     name: logging-project-id # kpt-set: ${logging-project-id}


### PR DESCRIPTION
Closes #660

Modify data access log configuration on the logging project in the core-landing-zone project, as per recommendation. This will help reduce logging costs.

Remove ADMIN_READ and DATA_WRITE from the config, leaving on DATA_READ

```yaml
  auditLogConfigs:
    - logType: DATA_READ
```