### PR TITLE
feat: remove disabling the _default bucket sink

### DIFF
--- a/solutions/core-landing-zone/mgmt-project/project-sink.yaml
+++ b/solutions/core-landing-zone/mgmt-project/project-sink.yaml
@@ -62,24 +62,3 @@ spec:
         "otel-collector" OR
         "krmapihosting-metrics-agent")
       name: exclude-gke-logs
----
-# Disable the _Default log bucket sink in the GKE KCC Cluster's management project
-# This prevents duplication of logs
-apiVersion: logging.cnrm.cloud.google.com/v1beta1
-kind: LoggingLogSink
-metadata:
-  name: mgmt-project-cluster-disable-default-bucket
-  namespace: logging
-  annotations:
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id}
-spec:
-  projectRef:
-    external: management-project-12345 # kpt-set: ${management-project-id}
-  destination:
-    # destination.loggingLogBucketRef
-    # Only `external` field is supported to configure the reference.
-    # AU-3, AU-3(1), AU-4(1), AU-6(4), AU-9(2)
-    loggingLogBucketRef:
-      external: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/_Default # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/_Default
-  resourceID: _Default
-  disabled: true


### PR DESCRIPTION
Closes #663

> Note

A patch command may be required to reconcile the root sync as remove this resource will attempt to delete the entire sink.

```shell
RESOURCE=logginglogsink.logging.cnrm.cloud.google.com/mgmt-project-cluster-disable-default-bucket
NAMESPACE=logging

kubectl patch $RESOURCE -n $NAMESPACE \
    --type json \
    --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
```