### PR TITLE
feat: enable logging on ComputeRouterNAT resources in experimentation client-project

### DIFF
--- a/solutions/experimentation/client-project/network/nat.yaml
+++ b/solutions/experimentation/client-project/network/nat.yaml
@@ -28,6 +28,9 @@ spec:
   routerRef:
     name: project-id-nane1-router # kpt-set: ${project-id}-nane1-router
   sourceSubnetworkIpRangesToNat: ALL_SUBNETWORKS_ALL_IP_RANGES
+  logConfig:
+    enable: true
+    filter: ALL
 ---
 # Cloud Router northamerica-northeast1
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
@@ -61,6 +64,9 @@ spec:
   routerRef:
     name: project-id-nane2-router # kpt-set: ${project-id}-nane2-router
   sourceSubnetworkIpRangesToNat: ALL_SUBNETWORKS_ALL_IP_RANGES
+  logConfig:
+    enable: true
+    filter: ALL
 ---
 # Cloud Router northamerica-northeast2
 apiVersion: compute.cnrm.cloud.google.com/v1beta1


### PR DESCRIPTION
Closes #670

Enable logging on ComputeRouterNAT resources in experimentation client-project package.

Enables logging for Cloud NAT
https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computerouternat

**Spec:**
```yaml
logConfig:
  enable: boolean
  filter: string
```

Spec to implement (ALL=Translation and errors):
```yaml
logConfig:
  enable: true
  filter: ALL
```
