### PR TITLE
feat: remove disabling the _default bucket sink in the mgmt project

### DIFF
--- a/solutions/experimentation/core-landing-zone/mgmt-project/project-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/mgmt-project/project-sink.yaml
@@ -61,23 +61,3 @@ spec:
         "otel-collector" OR
         "krmapihosting-metrics-agent")
       name: exclude-gke-logs
----
-# Disable the _Default log bucket sink in the GKE KCC Cluster's management project
-# This prevents duplication of logs
-apiVersion: logging.cnrm.cloud.google.com/v1beta1
-kind: LoggingLogSink
-metadata:
-  name: mgmt-project-cluster-disable-default-bucket
-  namespace: logging
-  annotations:
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id}
-spec:
-  projectRef:
-    external: management-project-12345 # kpt-set: ${management-project-id}
-  destination:
-    # destination.loggingLogBucketRef
-    # Only `external` field is supported to configure the reference.
-    loggingLogBucketRef:
-      external: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/_Default # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/_Default
-  resourceID: _Default
-  disabled: true


### PR DESCRIPTION
Closes #672

Remove disabling the _default bucket sink in the mgmt project in experimentation core-landing-zone package.

> Note

A patch command may be required to reconcile the root sync as removing this resource will attempt to delete the entire sink.

Once the resource is patched, the sink will need to be re-enabled using the Console or the gcloud cli:

*Replace `management-project-id` with your management project id

```shell
gcloud logging sinks update _Default --no-disabled --project=management-project-id
```

```shell
RESOURCE=logginglogsink.logging.cnrm.cloud.google.com/mgmt-project-cluster-disable-default-bucket
NAMESPACE=logging

kubectl patch $RESOURCE -n $NAMESPACE \
    --type json \
    --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
```