### PR TITLE
feat: remove disabling the _default bucket sink in the mgmt project

### DIFF
--- a/solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/project-iam.yaml
+++ b/solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/project-iam.yaml
@@ -97,9 +97,7 @@ metadata:
 spec:
   service: allServices
   auditLogConfigs:
-    - logType: ADMIN_READ
     - logType: DATA_READ
-    - logType: DATA_WRITE
   resourceRef:
     kind: Project
     name: logging-project-id # kpt-set: ${logging-project-id}


### PR DESCRIPTION
Closes #672

Modify data access log configuration on the logging project in the experimentation core-landing-zone package, as per recommendation. This will help reduce logging costs.

Remove ADMIN_READ and DATA_WRITE from the config, leaving on DATA_READ

```yaml
  auditLogConfigs:
    - logType: DATA_READ
```