### PR TITLE
feat: remove unused bigquery iam permissions

### DIFF
--- a/solutions/client-setup/namespaces/client-name-logging.yaml
+++ b/solutions/client-setup/namespaces/client-name-logging.yaml
@@ -63,24 +63,6 @@ spec:
   role: roles/monitoring.admin
   member: "serviceAccount:client-name-logging-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-logging-sa@${client-management-project-id}.iam.gserviceaccount.com
 ---
-# Grant GCP role BigQuery Admin to GCP SA
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
-metadata:
-  name: client-name-logging-sa-bigqueryadmin-permissions # kpt-set: ${client-name}-logging-sa-bigqueryadmin-permissions
-  namespace: hierarchy
-  annotations:
-    cnrm.cloud.google.com/ignore-clusterless: "true"
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/client-management-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${client-management-project-id}
-spec:
-  resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Folder
-    name: clients.client-name # kpt-set: clients.${client-name}
-  # AC-3, AC-3(7), AC-16(2)
-  role: roles/bigquery.admin
-  member: "serviceAccount:client-name-logging-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-logging-sa@${client-management-project-id}.iam.gserviceaccount.com
----
 # K8S SA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy

--- a/solutions/core-landing-zone/namespaces/logging.yaml
+++ b/solutions/core-landing-zone/namespaces/logging.yaml
@@ -44,24 +44,6 @@ spec:
   role: roles/logging.admin
   member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
 ---
-# Grant GCP role BigQuery Admin to GCP SA
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
-metadata:
-  name: logging-sa-bigqueryadmin-permissions
-  namespace: config-control # kpt-set: ${management-namespace}
-  annotations:
-    cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
-    cnrm.cloud.google.com/ignore-clusterless: "true"
-spec:
-  resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Folder
-    external: "123456789012" # kpt-set: ${lz-folder-id}
-  # AC-3(7), AC-3, AC-16(2)
-  role: roles/bigquery.admin
-  member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
----
 # K8S SA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy

--- a/solutions/experimentation/core-landing-zone/namespaces/logging.yaml
+++ b/solutions/experimentation/core-landing-zone/namespaces/logging.yaml
@@ -43,23 +43,6 @@ spec:
   role: roles/logging.admin
   member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
 ---
-# Grant GCP role BigQuery Admin to GCP SA
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
-metadata:
-  name: logging-sa-bigqueryadmin-permissions
-  namespace: config-control # kpt-set: ${management-namespace}
-  annotations:
-    cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
-    cnrm.cloud.google.com/ignore-clusterless: "true"
-spec:
-  resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Folder
-    external: "123456789012" # kpt-set: ${lz-folder-id}
-  role: roles/bigquery.admin
-  member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
----
 # K8S SA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy

--- a/solutions/legacy/landing-zone-v2/namespaces/logging.yaml
+++ b/solutions/legacy/landing-zone-v2/namespaces/logging.yaml
@@ -43,23 +43,6 @@ spec:
   role: roles/logging.admin
   member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
 ---
-# Grant GCP role BigQuery Admin to GCP SA
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
-metadata:
-  name: logging-sa-bigqueryadmin-permissions
-  namespace: config-control # kpt-set: ${management-namespace}
-  annotations:
-    cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
-    cnrm.cloud.google.com/ignore-clusterless: "true"
-spec:
-  resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Folder
-    external: "123456789012" # kpt-set: ${lz-folder-id}
-  role: roles/bigquery.admin
-  member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
----
 # K8S SA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy


### PR DESCRIPTION
Closes #682

Remove BigQuery IAM permissions since they are not required.

- client-setup
- core-landing-zone
- experimentation/core-landing-zone
- legacy/landing-zone-v2