### PR TITLE
feat: remove data access from org sink

### DIFF
--- a/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
+++ b/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ######
-# Logging project sink for Data Access logs (DATA_READ)
+# Logging project sink for Data Access logs
 # Destination: Cloud Logging bucket hosted inside logging project
 # AU-3, AU-3(1) - Sink defined at folder that will allow all the projects underneath the organization to send the logs to the logging bucket in the logging project
 # AU-4(1), AU-6(4), AU-9(2) - Log sinks sending the logs to same project in same region having a logging bucket
@@ -35,7 +35,7 @@ spec:
       # destination.loggingLogBucketRef
       # Only `external` field is supported to configure the reference.
       external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
-  description: Project sink for Data Access Logs (DATA_WRITE)
+  description: Project sink for Data Access Logs
   # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
   # AC-2(4), AU-12, AU-12(1)

--- a/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
+++ b/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
@@ -36,6 +36,8 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
   description: Project sink for Data Access Logs (DATA_WRITE)
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
+  disabled: false
   # AC-2(4), AU-12, AU-12(1)
   # Includes Security logs: Data Access
   # Security logs help you answer "who did what, where, and when"

--- a/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
+++ b/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
@@ -46,5 +46,5 @@ spec:
   #  Data Access
   #
   filter: |-
-    log_id("cloudaudit.googleapis.com/data_access")
+    log_id("cloudaudit.googleapis.com/data_access") OR log_id("externalaudit.googleapis.com/data_access")
 

--- a/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
+++ b/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
@@ -1,0 +1,47 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Logging project sink for Data Access logs (DATA_READ)
+# Destination: Cloud Logging bucket hosted inside logging project
+# AU-3, AU-3(1) - Sink defined at folder that will allow all the projects underneath the organization to send the logs to the logging bucket in the logging project
+# AU-4(1), AU-6(4), AU-9(2) - Log sinks sending the logs to same project in same region having a logging bucket
+# AC-2(4) - Includes Security logs: Data Access
+# AU-12, AU-12(1) - Log Sinks defined in Log Router check each log entry against the inclusion filter and exclusion filter that determine which destinations that the log entry is sent to
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogSink
+metadata:
+  name: logging-project-id-project-data-access-sink # kpt-set: ${logging-project-id}-project-data-access-sink
+  namespace: logging
+  annotations:
+    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}
+spec:
+  projectRef:
+    name: logging-project-id # kpt-set: ${logging-project-id}
+  destination:
+    # AU-3, AU-3(1), AU-4(1), AU-6(4), AU-9(2)
+    loggingLogBucketRef:
+      # destination.loggingLogBucketRef
+      # Only `external` field is supported to configure the reference.
+      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
+  description: Project sink for Data Access Logs (DATA_WRITE)
+  # AC-2(4), AU-12, AU-12(1)
+  # Includes Security logs: Data Access
+  # Security logs help you answer "who did what, where, and when"
+  #
+  # Cloud Audit Logs:
+  #  Data Access
+  #
+  filter: |-
+    log_id("cloudaudit.googleapis.com/data_access")
+

--- a/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
+++ b/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
@@ -21,7 +21,7 @@
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
 metadata:
-  name: logging-project-id-project-data-access-sink # kpt-set: ${logging-project-id}-project-data-access-sink
+  name: logging-project-id-data-access-sink # kpt-set: ${logging-project-id}-data-access-sink
   namespace: logging
   annotations:
     config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}

--- a/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
+++ b/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
@@ -28,6 +28,7 @@ metadata:
 spec:
   projectRef:
     name: logging-project-id # kpt-set: ${logging-project-id}
+    namespace: projects
   destination:
     # AU-3, AU-3(1), AU-4(1), AU-6(4), AU-9(2)
     loggingLogBucketRef:

--- a/solutions/core-landing-zone/org/org-sink.yaml
+++ b/solutions/core-landing-zone/org/org-sink.yaml
@@ -50,3 +50,42 @@ spec:
     OR log_id("cloudaudit.googleapis.com/system_event") OR log_id("externalaudit.googleapis.com/system_event")
     OR log_id("cloudaudit.googleapis.com/policy") OR log_id("externalaudit.googleapis.com/policy")
     OR log_id("cloudaudit.googleapis.com/access_transparency") OR log_id("externalaudit.googleapis.com/access_transparency")
+---
+# Organization sink for Data Access logs related to Google Workspace Login Audit
+# https://developers.google.com/admin-sdk/reports/v1/appendix/activity/login
+# Destination: Cloud Logging bucket hosted inside logging project
+# AU-3, AU-3(1) - Sink defined at folder that will allow all the projects underneath the organization to send the logs to the logging bucket in the logging project
+# AU-4(1), AU-6(4), AU-9(2) - Log sinks sending the logs to same project in same region having a logging bucket
+# AC-2(4) - Includes Security logs: Data Access
+# AU-12, AU-12(1) - Log Sinks defined in Log Router check each log entry against the inclusion filter and exclusion filter that determine which destinations that the log entry is sent to
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogSink
+metadata:
+  name: logging-project-id-security-data-access-sink # kpt-set: ${logging-project-id}-security-data-access-sink
+  namespace: logging
+  annotations:
+    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}
+spec:
+  organizationRef:
+    external: "0000000000" # kpt-set: ${org-id}
+  # Set includeChildren to False to prevent routing data access logs from other sources than the organization
+  includeChildren: False
+  destination:
+    # AU-3, AU-3(1), AU-4(1), AU-6(4), AU-9(2)
+    loggingLogBucketRef:
+      # destination.loggingLogBucketRef
+      # Only `external` field is supported to configure the reference.
+      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
+  description: Organization sink for Data Access Logs
+  # AC-2(4), AU-12, AU-12(1)
+  # Includes Security logs: Data Access
+  # Security logs help you answer "who did what, where, and when"
+  #
+  # Cloud Audit Logs:
+  #  Data Access
+  #
+  filter: |-
+    log_id("cloudaudit.googleapis.com/data_access")
+    resource.type="audited_resource"
+    resource.labels.service="login.googleapis.com"
+

--- a/solutions/core-landing-zone/org/org-sink.yaml
+++ b/solutions/core-landing-zone/org/org-sink.yaml
@@ -89,6 +89,6 @@ spec:
   #  Data Access
   #
   filter: |-
-    log_id("cloudaudit.googleapis.com/data_access")
+    log_id("cloudaudit.googleapis.com/data_access")  OR log_id("externalaudit.googleapis.com/data_access")
     resource.type="audited_resource"
     resource.labels.service="login.googleapis.com"

--- a/solutions/core-landing-zone/org/org-sink.yaml
+++ b/solutions/core-landing-zone/org/org-sink.yaml
@@ -79,6 +79,8 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
   description: Organization sink for Data Access Logs
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
+  disabled: false
   # AC-2(4), AU-12, AU-12(1)
   # Includes Security logs: Data Access
   # Security logs help you answer "who did what, where, and when"

--- a/solutions/core-landing-zone/org/org-sink.yaml
+++ b/solutions/core-landing-zone/org/org-sink.yaml
@@ -61,7 +61,7 @@ spec:
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
 metadata:
-  name: logging-project-id-security-data-access-sink # kpt-set: ${logging-project-id}-security-data-access-sink
+  name: logging-project-id-google-workspace-data-access-sink # kpt-set: ${logging-project-id}-google-workspace-data-access-sink
   namespace: logging
   annotations:
     config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}
@@ -88,4 +88,3 @@ spec:
     log_id("cloudaudit.googleapis.com/data_access")
     resource.type="audited_resource"
     resource.labels.service="login.googleapis.com"
-

--- a/solutions/core-landing-zone/org/org-sink.yaml
+++ b/solutions/core-landing-zone/org/org-sink.yaml
@@ -89,6 +89,6 @@ spec:
   #  Data Access
   #
   filter: |-
-    log_id("cloudaudit.googleapis.com/data_access")  OR log_id("externalaudit.googleapis.com/data_access")
+    log_id("cloudaudit.googleapis.com/data_access") OR log_id("externalaudit.googleapis.com/data_access")
     resource.type="audited_resource"
     resource.labels.service="login.googleapis.com"

--- a/solutions/core-landing-zone/org/org-sink.yaml
+++ b/solutions/core-landing-zone/org/org-sink.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ######
-# Organization sink for Security logs: Cloud Audit, Access Transparency, and Data Access Logs
+# Organization sink for Security logs: Cloud Audit and Access Transparency
 # Destination: Cloud Logging bucket hosted inside logging project
 # AU-3, AU-3(1) - Sink defined at folder that will allow all the projects underneath the organization to send the logs to the logging bucket in the logging project
 # AU-4(1), AU-6(4), AU-9(2) - Log sinks sending the logs to same project in same region having a logging bucket
-# AC-2(4) - Includes Security logs: Cloud Audit, Access Transparency, and Data Access Logs
+# AC-2(4) - Includes Security logs: Cloud Audit and Access Transparency
 # AU-12, AU-12(1) - Log Sinks defined in Log Router check each log entry against the inclusion filter and exclusion filter that determine which destinations that the log entry is sent to
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
@@ -37,19 +37,16 @@ spec:
       external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
   description: Organization sink for Security Logs
   # AC-2(4), AU-12, AU-12(1)
-  # Includes Security logs: Cloud Audit, Access Transparency, and Data Access Logs
+  # Includes Security logs: Cloud Audit and Access Transparency
   # Security logs help you answer "who did what, where, and when"
   #
   # Cloud Audit Logs:
   #  Admin Activity
-  #  Data Access
   #  System Events
   #  Policy Denied
   #
-  # Access Transparency Logs (TODO: - not enabled)
   filter: |-
     log_id("cloudaudit.googleapis.com/activity") OR log_id("externalaudit.googleapis.com/activity")
-    OR log_id("cloudaudit.googleapis.com/data_access") OR log_id("externalaudit.googleapis.com/data_access")
     OR log_id("cloudaudit.googleapis.com/system_event") OR log_id("externalaudit.googleapis.com/system_event")
     OR log_id("cloudaudit.googleapis.com/policy") OR log_id("externalaudit.googleapis.com/policy")
     OR log_id("cloudaudit.googleapis.com/access_transparency") OR log_id("externalaudit.googleapis.com/access_transparency")


### PR DESCRIPTION
Closes #685

Remove data access filtering on the org sink as per recommendation. This will prevent routing all data access logs to the security bucket. We will only route data access logs from the logging project (DATA_READ) into the security log bucket.

Remove data access from the current org sink
create a new sink strictly for data access logs, including the spec includeChildren: false
create sink on the logging project to route data access logs to the security log bucket.
Modify security control documentation.