### PR TITLE
fix: specify log sinks spec.disabled field value to false

### DIFF
--- a/solutions/client-landing-zone/client-folder/folder-sink.yaml
+++ b/solutions/client-landing-zone/client-folder/folder-sink.yaml
@@ -37,6 +37,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: platform-and-component-client-name-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/platform-and-component-${client-name}-log-bucket
   description: Folder sink for client-name Platform and Component logs # kpt-set: Folder sink for ${client-name} Platform and Component logs
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
   # AU-12, AU-12(1)
   # Includes the following types of logs:

--- a/solutions/client-landing-zone/client-folder/folder-sink.yaml
+++ b/solutions/client-landing-zone/client-folder/folder-sink.yaml
@@ -37,6 +37,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: platform-and-component-client-name-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/platform-and-component-${client-name}-log-bucket
   description: Folder sink for client-name Platform and Component logs # kpt-set: Folder sink for ${client-name} Platform and Component logs
+  disabled: false
   # AU-12, AU-12(1)
   # Includes the following types of logs:
   # Cloud DNS, Cloud NAT, Firewall Rules, VPC Flow, HTTP(S) Load Balancer and Intrusion Detection System (IDS)

--- a/solutions/core-landing-zone/lz-folder/services-infrastructure/folder-sink.yaml
+++ b/solutions/core-landing-zone/lz-folder/services-infrastructure/folder-sink.yaml
@@ -36,6 +36,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: platform-and-component-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${platform-and-component-log-bucket}
   description: Folder sink for Platform and Component logs of services Resources
+  disabled: false
   # AU-12, AU-12(1)
   # No inclusion filter. Includes all Platform and Component logs
   # Google Cloud platform logs are service-specific logs

--- a/solutions/core-landing-zone/lz-folder/services-infrastructure/folder-sink.yaml
+++ b/solutions/core-landing-zone/lz-folder/services-infrastructure/folder-sink.yaml
@@ -36,6 +36,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: platform-and-component-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${platform-and-component-log-bucket}
   description: Folder sink for Platform and Component logs of services Resources
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
   # AU-12, AU-12(1)
   # No inclusion filter. Includes all Platform and Component logs

--- a/solutions/core-landing-zone/lz-folder/services/folder-sink.yaml
+++ b/solutions/core-landing-zone/lz-folder/services/folder-sink.yaml
@@ -36,6 +36,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: platform-and-component-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${platform-and-component-log-bucket}
   description: Folder sink for Platform and Component logs of services Resources
+  disabled: false
   # AU-12, AU-12(1)
   # No inclusion filter. Includes all Platform and Component logs
   # Google Cloud platform logs are service-specific logs

--- a/solutions/core-landing-zone/lz-folder/services/folder-sink.yaml
+++ b/solutions/core-landing-zone/lz-folder/services/folder-sink.yaml
@@ -36,6 +36,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: platform-and-component-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${platform-and-component-log-bucket}
   description: Folder sink for Platform and Component logs of services Resources
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
   # AU-12, AU-12(1)
   # No inclusion filter. Includes all Platform and Component logs

--- a/solutions/core-landing-zone/mgmt-project/project-sink.yaml
+++ b/solutions/core-landing-zone/mgmt-project/project-sink.yaml
@@ -35,6 +35,7 @@ spec:
   # You must set unique_writer_identity to true if you wish to publish logs across projects
   uniqueWriterIdentity: true
   description: Project sink for Platform and Component logs of the Landing Zone Management Cluster
+  disabled: false
   # AU-12, AU-12(1)
   # No inclusion filter. Includes all Platform and Component logs
   # Google Cloud platform logs are service-specific logs

--- a/solutions/core-landing-zone/mgmt-project/project-sink.yaml
+++ b/solutions/core-landing-zone/mgmt-project/project-sink.yaml
@@ -35,6 +35,7 @@ spec:
   # You must set unique_writer_identity to true if you wish to publish logs across projects
   uniqueWriterIdentity: true
   description: Project sink for Platform and Component logs of the Landing Zone Management Cluster
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
   # AU-12, AU-12(1)
   # No inclusion filter. Includes all Platform and Component logs

--- a/solutions/core-landing-zone/org/org-sink.yaml
+++ b/solutions/core-landing-zone/org/org-sink.yaml
@@ -36,6 +36,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
   description: Organization sink for Security Logs
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
   # AC-2(4), AU-12, AU-12(1)
   # Includes Security logs: Cloud Audit, Access Transparency, and Data Access Logs

--- a/solutions/core-landing-zone/org/org-sink.yaml
+++ b/solutions/core-landing-zone/org/org-sink.yaml
@@ -36,6 +36,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
   description: Organization sink for Security Logs
+  disabled: false
   # AC-2(4), AU-12, AU-12(1)
   # Includes Security logs: Cloud Audit, Access Transparency, and Data Access Logs
   # Security logs help you answer "who did what, where, and when"

--- a/solutions/experimentation/client-landing-zone/client-folder/folder-sink.yaml
+++ b/solutions/experimentation/client-landing-zone/client-folder/folder-sink.yaml
@@ -32,6 +32,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: platform-and-component-client-name-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/platform-and-component-${client-name}-log-bucket
   description: Folder sink for client-name Platform and Component logs # kpt-set: Folder sink for ${client-name} Platform and Component logs
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
   # AU-2, AU-12(A), AU-12(C)
   # Includes the following types of logs:

--- a/solutions/experimentation/client-landing-zone/client-folder/folder-sink.yaml
+++ b/solutions/experimentation/client-landing-zone/client-folder/folder-sink.yaml
@@ -32,6 +32,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: platform-and-component-client-name-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/platform-and-component-${client-name}-log-bucket
   description: Folder sink for client-name Platform and Component logs # kpt-set: Folder sink for ${client-name} Platform and Component logs
+  disabled: false
   # AU-2, AU-12(A), AU-12(C)
   # Includes the following types of logs:
   # Cloud DNS, Cloud NAT, Firewall Rules, VPC Flow, and HTTP(S) Load Balancer

--- a/solutions/experimentation/core-landing-zone/lz-folder/tests/folder-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/lz-folder/tests/folder-sink.yaml
@@ -32,6 +32,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: platform-and-component-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/platform-and-component-log-bucket
   description: Folder sink for Platform and Component logs of Tests Resources
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
   # AU-2, AU-12(A), AU-12(C)
   # No inclusion filter. Includes all Platform and Component logs

--- a/solutions/experimentation/core-landing-zone/lz-folder/tests/folder-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/lz-folder/tests/folder-sink.yaml
@@ -32,6 +32,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: platform-and-component-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/platform-and-component-log-bucket
   description: Folder sink for Platform and Component logs of Tests Resources
+  disabled: false
   # AU-2, AU-12(A), AU-12(C)
   # No inclusion filter. Includes all Platform and Component logs
   # Google Cloud platform logs are service-specific logs

--- a/solutions/experimentation/core-landing-zone/mgmt-project/project-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/mgmt-project/project-sink.yaml
@@ -31,6 +31,7 @@ spec:
   # You must set unique_writer_identity to true if you wish to publish logs across projects
   uniqueWriterIdentity: true
   description: Project sink for Platform and Component logs of the Landing Zone Management Cluster
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
   # AU-2, AU-12(A), AU-12(C)
   # No inclusion filter. Includes all Platform and Component logs

--- a/solutions/experimentation/core-landing-zone/mgmt-project/project-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/mgmt-project/project-sink.yaml
@@ -31,6 +31,7 @@ spec:
   # You must set unique_writer_identity to true if you wish to publish logs across projects
   uniqueWriterIdentity: true
   description: Project sink for Platform and Component logs of the Landing Zone Management Cluster
+  disabled: false
   # AU-2, AU-12(A), AU-12(C)
   # No inclusion filter. Includes all Platform and Component logs
   # Google Cloud platform logs are service-specific logs

--- a/solutions/experimentation/core-landing-zone/org/org-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/org/org-sink.yaml
@@ -31,6 +31,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
   description: Organization sink for Security Logs
+  disabled: false
   # AU-2, AU-12(A), AU-12(C)
   # Includes Security logs: Cloud Audit, Access Transparency, and Data Access Logs
   # Security logs help you answer "who did what, where, and when"

--- a/solutions/experimentation/core-landing-zone/org/org-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/org/org-sink.yaml
@@ -31,6 +31,7 @@ spec:
       # Only `external` field is supported to configure the reference.
       external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
   description: Organization sink for Security Logs
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
   # AU-2, AU-12(A), AU-12(C)
   # Includes Security logs: Cloud Audit, Access Transparency, and Data Access Logs


### PR DESCRIPTION
closes #687

- explicitly set `spec.disabled` to false for `kind: LoggingLogSink`