### PR TITLE
fix: added dependabot file and adjusted permissions in release-please

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -2,12 +2,15 @@ on:
   push:
     branches:
       - main
-# Set permissions according to example action https://github.com/google-github-actions/release-please-action
-permissions:
-  contents: write
-  pull-requests: write
+# Set permissions to be read only
+permissions: read-all
+
 name: release-please
 jobs:
+  # Set permissions according to example action https://github.com/google-github-actions/release-please-action
+  permissions:
+    contents: write
+    pull-requests: write
   release-please:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Addressing a few more security issues the previous PR did not. Added dependabot to address [#2](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/security/code-scanning/2) and adjusted permission on release-please to be write at the job level but read-only at the global level [#28](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/security/code-scanning/28)