### PR TITLE
fix: adjusted release-please permissions to be under job name

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -7,11 +7,11 @@ permissions: read-all
 
 name: release-please
 jobs:
-  # Set permissions according to example action https://github.com/google-github-actions/release-please-action
-  permissions:
-    contents: write
-    pull-requests: write
   release-please:
+    # Set permissions according to example action https://github.com/google-github-actions/release-please-action
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3


### PR DESCRIPTION
Adjusts release please permissions to be under `release-please` block in the github actions definition instead of under `jobs`.