### PR TITLE
feat: modify data access filtering from org sink and add new sinks in experimentation

### DIFF
--- a/solutions/experimentation/core-landing-zone/README.md
+++ b/solutions/experimentation/core-landing-zone/README.md
@@ -16,12 +16,12 @@ Depends on the bootstrap procedure.
 | allowed-contact-domains       | ["@example.com"]          | array |     1 |
 | allowed-policy-domain-members | ["DIRECTORY_CUSTOMER_ID"] | array |     1 |
 | billing-id                    | AAAAAA-BBBBBB-CCCCCC      | str   |     1 |
-| logging-project-id            | logging-project-12345     | str   |    17 |
+| logging-project-id            | logging-project-12345     | str   |    20 |
 | lz-folder-id                  |                0000000000 | str   |    13 |
 | management-namespace          | config-control            | str   |    33 |
 | management-project-id         | management-project-12345  | str   |    67 |
 | management-project-number     |                0000000000 | str   |     3 |
-| org-id                        |                0000000000 | str   |    15 |
+| org-id                        |                0000000000 | str   |    16 |
 | retention-in-days             |                         1 | int   |     2 |
 | retention-locking-policy      | false                     | bool  |     2 |
 
@@ -40,6 +40,7 @@ This package has no sub-packages.
 | lz-folder/audits/logging-project/project-iam.yaml               | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | platform-and-component-log-bucket-writer-permissions                      | projects          |
 | lz-folder/audits/logging-project/project-iam.yaml               | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | mgmt-project-cluster-platform-and-component-log-bucket-writer-permissions | projects          |
 | lz-folder/audits/logging-project/project-iam.yaml               | iam.cnrm.cloud.google.com/v1beta1             | IAMAuditConfig         | logging-project-data-access-log-config                                    | projects          |
+| lz-folder/audits/logging-project/project-sink.yaml              | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink         | logging-project-id-data-access-sink                                       | logging           |
 | lz-folder/audits/logging-project/project.yaml                   | resourcemanager.cnrm.cloud.google.com/v1beta1 | Project                | logging-project-id                                                        | projects          |
 | lz-folder/clients/folder.yaml                                   | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                 | clients                                                                   | hierarchy         |
 | lz-folder/tests/admins/folder.yaml                              | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                 | tests.admins                                                              | hierarchy         |
@@ -109,6 +110,7 @@ This package has no sub-packages.
 | org/org-policies/iam-allowed-policy-member-domains.yaml         | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | iam-allowed-policy-member-domains                                         | policies          |
 | org/org-policies/storage-uniform-bucket-level-access.yaml       | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | storage-uniform-bucket-level-access                                       | policies          |
 | org/org-sink.yaml                                               | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink         | logging-project-id-security-sink                                          | logging           |
+| org/org-sink.yaml                                               | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink         | logging-project-id-google-workspace-data-access-sink                      | logging           |
 
 ## Resource References
 

--- a/solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
@@ -1,0 +1,49 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######
+# Logging project sink for Data Access logs
+# Destination: Cloud Logging bucket hosted inside logging project
+# AU-3, AU-3(1) - Sink defined at folder that will allow all the projects underneath the organization to send the logs to the logging bucket in the logging project
+# AU-4(1), AU-6(4), AU-9(2) - Log sinks sending the logs to same project in same region having a logging bucket
+# AC-2(4) - Includes Security logs: Data Access
+# AU-12, AU-12(1) - Log Sinks defined in Log Router check each log entry against the inclusion filter and exclusion filter that determine which destinations that the log entry is sent to
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogSink
+metadata:
+  name: logging-project-id-data-access-sink # kpt-set: ${logging-project-id}-data-access-sink
+  namespace: logging
+  annotations:
+    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}
+spec:
+  projectRef:
+    name: logging-project-id # kpt-set: ${logging-project-id}
+    namespace: projects
+  destination:
+    # AU-3, AU-3(1), AU-4(1), AU-6(4), AU-9(2)
+    loggingLogBucketRef:
+      # destination.loggingLogBucketRef
+      # Only `external` field is supported to configure the reference.
+      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
+  description: Project sink for Data Access Logs
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
+  disabled: false
+  # AC-2(4), AU-12, AU-12(1)
+  # Includes Security logs: Data Access
+  # Security logs help you answer "who did what, where, and when"
+  #
+  # Cloud Audit Logs:
+  #  Data Access
+  #
+  filter: |-
+    log_id("cloudaudit.googleapis.com/data_access") OR log_id("externalaudit.googleapis.com/data_access")

--- a/solutions/experimentation/core-landing-zone/org/org-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/org/org-sink.yaml
@@ -14,7 +14,10 @@
 ######
 # Organization sink for Security logs: Cloud Audit and Access Transparency
 # Destination: Cloud Logging bucket hosted inside logging project
-# TODO: update security control documentation
+# AU-3, AU-3(1) - Sink defined at folder that will allow all the projects underneath the organization to send the logs to the logging bucket in the logging project
+# AU-4(1), AU-6(4), AU-9(2) - Log sinks sending the logs to same project in same region having a logging bucket
+# AC-2(4) - Includes Security logs: Cloud Audit and Access Transparency
+# AU-12, AU-12(1) - Log Sinks defined in Log Router check each log entry against the inclusion filter and exclusion filter that determine which destinations that the log entry is sent to
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
 metadata:
@@ -43,7 +46,6 @@ spec:
   #  System Events
   #  Policy Denied
   #
-  # Access Transparency Logs (TODO - not enabled)
   filter: |-
     log_id("cloudaudit.googleapis.com/activity") OR log_id("externalaudit.googleapis.com/activity")
     OR log_id("cloudaudit.googleapis.com/system_event") OR log_id("externalaudit.googleapis.com/system_event")

--- a/solutions/experimentation/core-landing-zone/org/org-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/org/org-sink.yaml
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ######
-# Organization sink for Security logs: Cloud Audit, Access Transparency, and Data Access Logs
+# Organization sink for Security logs: Cloud Audit and Access Transparency
 # Destination: Cloud Logging bucket hosted inside logging project
+# TODO: update security control documentation
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
 metadata:
@@ -34,19 +35,57 @@ spec:
   # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
   # AU-2, AU-12(A), AU-12(C)
-  # Includes Security logs: Cloud Audit, Access Transparency, and Data Access Logs
+  # Includes Security logs: Cloud Audit and Access Transparency
   # Security logs help you answer "who did what, where, and when"
   #
   # Cloud Audit Logs:
   #  Admin Activity
-  #  Data Access
   #  System Events
   #  Policy Denied
   #
   # Access Transparency Logs (TODO - not enabled)
   filter: |-
     log_id("cloudaudit.googleapis.com/activity") OR log_id("externalaudit.googleapis.com/activity")
-    OR log_id("cloudaudit.googleapis.com/data_access") OR log_id("externalaudit.googleapis.com/data_access")
     OR log_id("cloudaudit.googleapis.com/system_event") OR log_id("externalaudit.googleapis.com/system_event")
     OR log_id("cloudaudit.googleapis.com/policy") OR log_id("externalaudit.googleapis.com/policy")
     OR log_id("cloudaudit.googleapis.com/access_transparency") OR log_id("externalaudit.googleapis.com/access_transparency")
+---
+# Organization sink for Data Access logs related to Google Workspace Login Audit
+# https://developers.google.com/admin-sdk/reports/v1/appendix/activity/login
+# Destination: Cloud Logging bucket hosted inside logging project
+# AU-3, AU-3(1) - Sink defined at folder that will allow all the projects underneath the organization to send the logs to the logging bucket in the logging project
+# AU-4(1), AU-6(4), AU-9(2) - Log sinks sending the logs to same project in same region having a logging bucket
+# AC-2(4) - Includes Security logs: Data Access
+# AU-12, AU-12(1) - Log Sinks defined in Log Router check each log entry against the inclusion filter and exclusion filter that determine which destinations that the log entry is sent to
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogSink
+metadata:
+  name: logging-project-id-google-workspace-data-access-sink # kpt-set: ${logging-project-id}-google-workspace-data-access-sink
+  namespace: logging
+  annotations:
+    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}
+spec:
+  organizationRef:
+    external: "0000000000" # kpt-set: ${org-id}
+  # Set includeChildren to False to prevent routing data access logs from other sources than the organization
+  includeChildren: False
+  destination:
+    # AU-3, AU-3(1), AU-4(1), AU-6(4), AU-9(2)
+    loggingLogBucketRef:
+      # destination.loggingLogBucketRef
+      # Only `external` field is supported to configure the reference.
+      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
+  description: Organization sink for Data Access Logs
+  # the log sink must be enabled (disabled: false) to meet the listed security controls
+  disabled: false
+  # AC-2(4), AU-12, AU-12(1)
+  # Includes Security logs: Data Access
+  # Security logs help you answer "who did what, where, and when"
+  #
+  # Cloud Audit Logs:
+  #  Data Access
+  #
+  filter: |-
+    log_id("cloudaudit.googleapis.com/data_access") OR log_id("externalaudit.googleapis.com/data_access")
+    resource.type="audited_resource"
+    resource.labels.service="login.googleapis.com"

--- a/solutions/experimentation/core-landing-zone/setters.yaml
+++ b/solutions/experimentation/core-landing-zone/setters.yaml
@@ -76,6 +76,10 @@ data:
   #
   logging-project-id: logging-project-12345
   #
+  # Log Buckets
+  # Security Logs Bucket
+  # customization: required
+  security-log-bucket: security-log-bucket-12345
   # Retention settings
   # Set the number of days to retain logs in Cloud Logging buckets
   # Set the lock mechanism on the bucket to: true or false


### PR DESCRIPTION
Closes #701

Remove data access filtering on the org sink as per recommendation. This will prevent routing all data access logs to the security bucket. We will only route data access logs from the logging project (DATA_READ) into the security log bucket.

Remove data access from the current org sink
create a new sink strictly for data access logs, including the spec includeChildren: false
create sink on the logging project to route data access logs to the security log bucket.
Modify security control documentation.