### PR TITLE
fix: rename org sinks add security log bucket

### DIFF
--- a/solutions/core-landing-zone/README.md
+++ b/solutions/core-landing-zone/README.md
@@ -36,7 +36,6 @@ Attention, validate impact with CCCS Cloud Based Sensors before implementing any
 | security-incident-log-bucket                          | security-incident-log-bucket-12345      | str   |     1 |
 | security-incident-log-bucket-retention-in-seconds     |                                   86400 | int   |     1 |
 | security-incident-log-bucket-retention-locking-policy | false                                   | bool  |     1 |
-| security-log-bucket                                   | security-log-bucket-12345               | str   |     1 |
 
 ## Sub-packages
 
@@ -158,8 +157,8 @@ This package has no sub-packages.
 | org/org-policies/sql-restrict-public-ip.yaml                                          | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | sql-restrict-public-ip                                                    | policies          |
 | org/org-policies/storage-public-access-prevention.yaml                                | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | storage-public-access-prevention                                          | policies          |
 | org/org-policies/storage-uniform-bucket-level-access.yaml                             | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | storage-uniform-bucket-level-access                                       | policies          |
-| org/org-sink.yaml                                                                     | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink         | logging-project-id-security-sink                                          | logging           |
-| org/org-sink.yaml                                                                     | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink         | logging-project-id-google-workspace-data-access-sink                      | logging           |
+| org/org-sink.yaml                                                                     | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink         | org-log-sink-security-logging-project-id                                  | logging           |
+| org/org-sink.yaml                                                                     | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink         | org-log-sink-data-access-logging-project-id                               | logging           |
 
 ## Resource References
 

--- a/solutions/core-landing-zone/lz-folder/audits/logging-project/cloud-logging-buckets.yaml
+++ b/solutions/core-landing-zone/lz-folder/audits/logging-project/cloud-logging-buckets.yaml
@@ -19,7 +19,7 @@
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogBucket
 metadata:
-  name: security-log-bucket # kpt-set: ${security-log-bucket}
+  name: security-log-bucket
   namespace: logging
   annotations:
     config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id}

--- a/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
+++ b/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
@@ -34,7 +34,7 @@ spec:
     loggingLogBucketRef:
       # destination.loggingLogBucketRef
       # Only `external` field is supported to configure the reference.
-      external: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
+      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
   description: Project sink for Data Access Logs
   # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false

--- a/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
+++ b/solutions/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
@@ -24,7 +24,7 @@ metadata:
   name: logging-project-id-data-access-sink # kpt-set: ${logging-project-id}-data-access-sink
   namespace: logging
   annotations:
-    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}
+    config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/security-log-bucket
 spec:
   projectRef:
     name: logging-project-id # kpt-set: ${logging-project-id}
@@ -34,7 +34,7 @@ spec:
     loggingLogBucketRef:
       # destination.loggingLogBucketRef
       # Only `external` field is supported to configure the reference.
-      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
+      external: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
   description: Project sink for Data Access Logs
   # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false

--- a/solutions/core-landing-zone/org/org-sink.yaml
+++ b/solutions/core-landing-zone/org/org-sink.yaml
@@ -21,7 +21,6 @@
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
 metadata:
-  # Compliance as Code (CaC) requires the following naming convention for the security log org sink
   name: org-log-sink-security-logging-project-id # kpt-set: org-log-sink-security-${logging-project-id}
   namespace: logging
   annotations:
@@ -64,7 +63,6 @@ spec:
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
 metadata:
-  # Compliance as Code (CaC) requires the following naming convention for the security log org sink
   name: org-log-sink-data-access-logging-project-id # kpt-set: org-log-sink-data-access-${logging-project-id}
   namespace: logging
   annotations:

--- a/solutions/core-landing-zone/org/org-sink.yaml
+++ b/solutions/core-landing-zone/org/org-sink.yaml
@@ -21,7 +21,8 @@
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
 metadata:
-  name: logging-project-id-security-sink # kpt-set: ${logging-project-id}-security-sink
+  # Compliance as Code (CaC) requires the following naming convention for the security log org sink
+  name: org-log-sink-security-logging-project-id # kpt-set: org-log-sink-security-${logging-project-id}
   namespace: logging
   annotations:
     config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}
@@ -63,7 +64,8 @@ spec:
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
 metadata:
-  name: logging-project-id-google-workspace-data-access-sink # kpt-set: ${logging-project-id}-google-workspace-data-access-sink
+  # Compliance as Code (CaC) requires the following naming convention for the security log org sink
+  name: org-log-sink-data-access-logging-project-id # kpt-set: org-log-sink-data-access-${logging-project-id}
   namespace: logging
   annotations:
     config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}

--- a/solutions/core-landing-zone/org/org-sink.yaml
+++ b/solutions/core-landing-zone/org/org-sink.yaml
@@ -25,7 +25,7 @@ metadata:
   name: org-log-sink-security-logging-project-id # kpt-set: org-log-sink-security-${logging-project-id}
   namespace: logging
   annotations:
-    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}
+    config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/security-log-bucket
 spec:
   organizationRef:
     external: "0000000000" # kpt-set: ${org-id}
@@ -35,7 +35,7 @@ spec:
     loggingLogBucketRef:
       # destination.loggingLogBucketRef
       # Only `external` field is supported to configure the reference.
-      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
+      external: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
   description: Organization sink for Security Logs
   # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
@@ -68,7 +68,7 @@ metadata:
   name: org-log-sink-data-access-logging-project-id # kpt-set: org-log-sink-data-access-${logging-project-id}
   namespace: logging
   annotations:
-    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}
+    config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/security-log-bucket
 spec:
   organizationRef:
     external: "0000000000" # kpt-set: ${org-id}
@@ -79,7 +79,7 @@ spec:
     loggingLogBucketRef:
       # destination.loggingLogBucketRef
       # Only `external` field is supported to configure the reference.
-      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
+      external: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
   description: Organization sink for Data Access Logs
   # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false

--- a/solutions/core-landing-zone/org/org-sink.yaml
+++ b/solutions/core-landing-zone/org/org-sink.yaml
@@ -35,7 +35,7 @@ spec:
     loggingLogBucketRef:
       # destination.loggingLogBucketRef
       # Only `external` field is supported to configure the reference.
-      external: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
+      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
   description: Organization sink for Security Logs
   # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false
@@ -79,7 +79,7 @@ spec:
     loggingLogBucketRef:
       # destination.loggingLogBucketRef
       # Only `external` field is supported to configure the reference.
-      external: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
+      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
   description: Organization sink for Data Access Logs
   # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false

--- a/solutions/core-landing-zone/setters.yaml
+++ b/solutions/core-landing-zone/setters.yaml
@@ -111,11 +111,6 @@ data:
   # customization: required
   logging-project-id: logging-project-12345
   #
-  # Log Buckets
-  # Security Logs Bucket
-  # customization: required
-  security-log-bucket: security-log-bucket-12345
-  #
   # Storage buckets
   # Security incident log bucket
   # Bucket names must be globally unique across all of GCP


### PR DESCRIPTION
Closes #706 

As per the discussion with CaC folks, we will rename our security log sink and data access sink as follows to be compliant:

org-log-sink-security-{logging-project-id}
org-log-sink-data-access-{logging-project-id}

For the security log bucket, we will hardcode the value to `security-log-bucket` and remove the value from the setters, as this resource is not required to be globally unique.