### PR TITLE
fix: rename org sinks and security log bucket

### DIFF
--- a/solutions/experimentation/core-landing-zone/README.md
+++ b/solutions/experimentation/core-landing-zone/README.md
@@ -109,8 +109,8 @@ This package has no sub-packages.
 | org/org-policies/gcp-resource-locations.yaml                    | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | gcp-restrict-resource-locations                                           | policies          |
 | org/org-policies/iam-allowed-policy-member-domains.yaml         | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | iam-allowed-policy-member-domains                                         | policies          |
 | org/org-policies/storage-uniform-bucket-level-access.yaml       | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | storage-uniform-bucket-level-access                                       | policies          |
-| org/org-sink.yaml                                               | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink         | logging-project-id-security-sink                                          | logging           |
-| org/org-sink.yaml                                               | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink         | logging-project-id-google-workspace-data-access-sink                      | logging           |
+| org/org-sink.yaml                                               | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink         | org-log-sink-security-logging-project-id                                  | logging           |
+| org/org-sink.yaml                                               | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink         | org-log-sink-data-access-logging-project-id                               | logging           |
 
 ## Resource References
 

--- a/solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
@@ -24,7 +24,7 @@ metadata:
   name: logging-project-id-data-access-sink # kpt-set: ${logging-project-id}-data-access-sink
   namespace: logging
   annotations:
-    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/security-log-bucket
+    config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/security-log-bucket
 spec:
   projectRef:
     name: logging-project-id # kpt-set: ${logging-project-id}

--- a/solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/project-sink.yaml
@@ -24,7 +24,7 @@ metadata:
   name: logging-project-id-data-access-sink # kpt-set: ${logging-project-id}-data-access-sink
   namespace: logging
   annotations:
-    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}
+    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/security-log-bucket
 spec:
   projectRef:
     name: logging-project-id # kpt-set: ${logging-project-id}
@@ -34,7 +34,7 @@ spec:
     loggingLogBucketRef:
       # destination.loggingLogBucketRef
       # Only `external` field is supported to configure the reference.
-      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
+      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
   description: Project sink for Data Access Logs
   # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false

--- a/solutions/experimentation/core-landing-zone/org/org-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/org/org-sink.yaml
@@ -21,7 +21,7 @@
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
 metadata:
-  name: logging-project-id-security-sink # kpt-set: ${logging-project-id}-security-sink
+  name: org-log-sink-security-logging-project-id # kpt-set: org-log-sink-security-${logging-project-id}
   namespace: logging
   annotations:
     config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/security-log-bucket
@@ -62,7 +62,7 @@ spec:
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogSink
 metadata:
-  name: logging-project-id-google-workspace-data-access-sink # kpt-set: ${logging-project-id}-google-workspace-data-access-sink
+  name: org-log-sink-data-access-logging-project-id # kpt-set: org-log-sink-data-access-${logging-project-id}
   namespace: logging
   annotations:
     config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/security-log-bucket

--- a/solutions/experimentation/core-landing-zone/org/org-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/org/org-sink.yaml
@@ -65,7 +65,7 @@ metadata:
   name: org-log-sink-data-access-logging-project-id # kpt-set: org-log-sink-data-access-${logging-project-id}
   namespace: logging
   annotations:
-    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/security-log-bucket
+    config.kubernetes.io/depends-on: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/security-log-bucket
 spec:
   organizationRef:
     external: "0000000000" # kpt-set: ${org-id}

--- a/solutions/experimentation/core-landing-zone/org/org-sink.yaml
+++ b/solutions/experimentation/core-landing-zone/org/org-sink.yaml
@@ -65,7 +65,7 @@ metadata:
   name: logging-project-id-google-workspace-data-access-sink # kpt-set: ${logging-project-id}-google-workspace-data-access-sink
   namespace: logging
   annotations:
-    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/${security-log-bucket}
+    config.kubernetes.io/depends-on: security-log-bucket # kpt-set: logging.cnrm.cloud.google.com/namespaces/logging/LoggingLogBucket/security-log-bucket
 spec:
   organizationRef:
     external: "0000000000" # kpt-set: ${org-id}
@@ -76,7 +76,7 @@ spec:
     loggingLogBucketRef:
       # destination.loggingLogBucketRef
       # Only `external` field is supported to configure the reference.
-      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/${security-log-bucket}
+      external: security-log-bucket # kpt-set: logging.googleapis.com/projects/${logging-project-id}/locations/northamerica-northeast1/buckets/security-log-bucket
   description: Organization sink for Data Access Logs
   # the log sink must be enabled (disabled: false) to meet the listed security controls
   disabled: false

--- a/solutions/experimentation/core-landing-zone/setters.yaml
+++ b/solutions/experimentation/core-landing-zone/setters.yaml
@@ -76,10 +76,6 @@ data:
   #
   logging-project-id: logging-project-12345
   #
-  # Log Buckets
-  # Security Logs Bucket
-  # customization: required
-  security-log-bucket: security-log-bucket-12345
   # Retention settings
   # Set the number of days to retain logs in Cloud Logging buckets
   # Set the lock mechanism on the bucket to: true or false


### PR DESCRIPTION
Closes #708

As discussed with CaC folks, we will rename our security log sink and data access sink to comply.

Changes for experimentation/core-landing-zone package:

org-log-sink-security-{logging-project-id}
org-log-sink-data-access-{logging-project-id}

For the security log bucket, we will hardcode the value to `security-log-bucket` and remove the value from the setters, as this resource is not required to be globally unique.