### PR TITLE
fix: revert client-folder name to original value 

### DIFF
--- a/solutions/client-setup/folder.yaml
+++ b/solutions/client-setup/folder.yaml
@@ -18,6 +18,6 @@ metadata:
   name: clients.client-name # kpt-set: clients.${client-name}
   namespace: hierarchy
 spec:
-  displayName: client-name # kpt-set: ${client-name}-${environment}
+  displayName: client-name # kpt-set: ${client-name}
   folderRef:
     name: clients

--- a/solutions/client-setup/setters.yaml
+++ b/solutions/client-setup/setters.yaml
@@ -42,10 +42,6 @@ data:
   # customization: required
   org-id: "0000000000"
   #
-  # The environment (dev, preprod, prod), used in the client folder display name
-  # customization: required
-  environment: env
-  #
   ##########################
   # Management Project
   ##########################


### PR DESCRIPTION
revert client-folder name to original value by removing the environment from the name