### PR TITLE
fix: update stale org sink refs

### DIFF
--- a/solutions/core-landing-zone/README.md
+++ b/solutions/core-landing-zone/README.md
@@ -26,8 +26,8 @@ Attention, validate impact with CCCS Cloud Based Sensors before implementing any
 | dns-project-id                                        | dns-project-12345                       | str   |     8 |
 | logging-project-id                                    | logging-project-12345                   | str   |    36 |
 | lz-folder-id                                          |                              0000000000 | str   |    14 |
-| management-namespace                                  | config-control                          | str   |    47 |
-| management-project-id                                 | management-project-12345                | str   |    92 |
+| management-namespace                                  | config-control                          | str   |    48 |
+| management-project-id                                 | management-project-12345                | str   |    94 |
 | management-project-number                             |                              0000000000 | str   |     3 |
 | org-id                                                |                              0000000000 | str   |    42 |
 | platform-and-component-log-bucket                     | platform-and-component-log-bucket-12345 | str   |     2 |
@@ -75,6 +75,7 @@ This package has no sub-packages.
 | mgmt-project/services.yaml                                                            | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                    | management-project-id-cloudresourcemanager                                | config-control               |
 | mgmt-project/services.yaml                                                            | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                    | management-project-id-serviceusage                                        | config-control               |
 | mgmt-project/services.yaml                                                            | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                    | management-project-id-accesscontextmanager                                | config-control               |
+| mgmt-project/services.yaml                                                            | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                    | management-project-id-anthos                                              | config-control               |
 | namespaces/config-management-monitoring.yaml                                          | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount          | config-mgmt-mon-default-sa                                                | config-control               |
 | namespaces/config-management-monitoring.yaml                                          | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember            | config-mgmt-mon-default-sa-metric-writer-permissions                      | config-control               |
 | namespaces/config-management-monitoring.yaml                                          | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy           | config-mgmt-mon-default-sa-workload-identity-binding                      | config-control               |

--- a/solutions/core-landing-zone/lz-folder/audits/logging-project/project-iam.yaml
+++ b/solutions/core-landing-zone/lz-folder/audits/logging-project/project-iam.yaml
@@ -33,7 +33,7 @@ spec:
       members:
         - memberFrom:
             logSinkRef:
-              name: logging-project-id-security-sink # kpt-set: ${logging-project-id}-security-sink
+              name: org-log-sink-security-logging-project-id # kpt-set: org-log-sink-security-${logging-project-id}
               namespace: logging
 ---
 # Logs Bucket writer IAM permissions for the platform and component log sinks

--- a/solutions/experimentation/core-landing-zone/README.md
+++ b/solutions/experimentation/core-landing-zone/README.md
@@ -18,8 +18,8 @@ Depends on the bootstrap procedure.
 | billing-id                    | AAAAAA-BBBBBB-CCCCCC      | str   |     1 |
 | logging-project-id            | logging-project-12345     | str   |    20 |
 | lz-folder-id                  |                0000000000 | str   |    13 |
-| management-namespace          | config-control            | str   |    33 |
-| management-project-id         | management-project-12345  | str   |    67 |
+| management-namespace          | config-control            | str   |    34 |
+| management-project-id         | management-project-12345  | str   |    69 |
 | management-project-number     |                0000000000 | str   |     3 |
 | org-id                        |                0000000000 | str   |    16 |
 | retention-in-days             |                         1 | int   |     2 |
@@ -51,6 +51,7 @@ This package has no sub-packages.
 | mgmt-project/services.yaml                                      | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                | management-project-id-cloudbilling                                        | config-control    |
 | mgmt-project/services.yaml                                      | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                | management-project-id-cloudresourcemanager                                | config-control    |
 | mgmt-project/services.yaml                                      | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                | management-project-id-serviceusage                                        | config-control    |
+| mgmt-project/services.yaml                                      | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                | management-project-id-anthos                                              | config-control    |
 | namespaces/gatekeeper-system.yaml                               | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount      | gatekeeper-admin-sa                                                       | config-control    |
 | namespaces/gatekeeper-system.yaml                               | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | gatekeeper-admin-sa-metric-writer-permissions                             | config-control    |
 | namespaces/gatekeeper-system.yaml                               | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | gatekeeper-admin-sa-workload-identity-binding                             | config-control    |

--- a/solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/project-iam.yaml
+++ b/solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/project-iam.yaml
@@ -36,7 +36,7 @@ spec:
       members:
         - memberFrom:
             logSinkRef:
-              name: logging-project-id-security-sink # kpt-set: ${logging-project-id}-security-sink
+              name: org-log-sink-security-logging-project-id # kpt-set: org-log-sink-security-${logging-project-id}
               namespace: logging
 ---
 # Logs Bucket writer IAM permissions for the platform and component log sink


### PR DESCRIPTION
Closes #715

Refer to #707

Update stale security log refs in the following packages:

- solutions/core-landing-zone/lz-folder/audits/logging-project/project-iam.yaml
- solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/project-iam.yaml

From:
`logging-project-id-security-sink # kpt-set: ${logging-project-id}-security-sink`

To:
`org-log-sink-security-logging-project-id # kpt-set: org-log-sink-security-${logging-project-id}`