### PR TITLE
feat: cloud armor - upgrade preconfigured waf list to v33

### DIFF
--- a/examples/landing-zone-v2/configconnector/tier3/cloud-armor/security-policy.yaml
+++ b/examples/landing-zone-v2/configconnector/tier3/cloud-armor/security-policy.yaml
@@ -26,41 +26,69 @@ spec:
   resourceID: workload-name-security-policy # kpt-set: ${workload-name}-security-policy
   rule:
     - action: deny(403)
-      description: block preconfiguredWAF list
+      description: Deny Local File Inclusion
       match:
         expr:
-          expression: |
-            evaluatePreconfiguredExpr('lfi-v33-stable')
-            || evaluatePreconfiguredExpr('rfi-v33-stable')
-            || evaluatePreconfiguredExpr('rce-v33-stable')
-            || evaluatePreconfiguredExpr('methodenforcement-v33-stable')
-            || evaluatePreconfiguredExpr('scannerdetection-v33-stable')
+          expression: "evaluatePreconfiguredWaf('lfi-v33-stable', {'sensitivity': 4})"
       priority: 10000
     - action: deny(403)
-      description: block preconfiguredWAF list - part2
+      description: Deny Remote File Inclusion
       match:
         expr:
-          expression: |
-            evaluatePreconfiguredExpr('protocolattack-v33-stable')
-            || evaluatePreconfiguredExpr('sessionfixation-v33-stable')
-            || evaluatePreconfiguredExpr('xss-v33-stable')
+          expression: "evaluatePreconfiguredWaf('rfi-v33-stable', {'sensitivity': 4})"
       priority: 10001
+    - action: deny(403)
+      description: Deny Remote Code Execution
+      match:
+        expr:
+          expression: "evaluatePreconfiguredWaf('rce-v33-stable', {'sensitivity': 4})"
+      priority: 10002
+    - action: deny(403)
+      description: Deny Method Enforcement
+      match:
+        expr:
+          expression: "evaluatePreconfiguredWaf('methodenforcement-v33-stable', {'sensitivity': 4})"
+      priority: 10003
+    - action: deny(403)
+      description: Deny Scanner Detection
+      match:
+        expr:
+          expression: "evaluatePreconfiguredWaf('scannerdetection-v33-stable', {'sensitivity': 4})"
+      priority: 10004
+    - action: deny(403)
+      description: Deny Protocol Attack
+      match:
+        expr:
+          expression: "evaluatePreconfiguredWaf('protocolattack-v33-stable', {'sensitivity': 4})"
+      priority: 10005
+    - action: deny(403)
+      description: Deny Session Fixation
+      match:
+        expr:
+          expression: "evaluatePreconfiguredWaf('sessionfixation-v33-stable', {'sensitivity': 4})"
+      priority: 10006
+    - action: deny(403)
+      description: Deny Cross-Site Scripting
+      match:
+        expr:
+          expression: "evaluatePreconfiguredWaf('xss-v33-stable', {'sensitivity': 4})"
+      priority: 10007
     - action: allow
-      description: allow Canada
+      description: Allow Canada
       match:
         expr:
           expression: |
             '[CA]'.contains(origin.region_code)
       priority: 100001
     - action: allow
-      description: allow Google monitoring
+      description: Allow Google Monitoring
       match:
         expr:
           expression: |
             request.headers['user-agent'].contains('GoogleStackdriverMonitoring-UptimeChecks')
       priority: 100000
     - action: allow
-      description: allow web security scanner
+      description: Allow Web Security Scanner
       match:
         config:
           srcIpRanges:

--- a/examples/landing-zone-v2/configconnector/tier3/cloud-armor/security-policy.yaml
+++ b/examples/landing-zone-v2/configconnector/tier3/cloud-armor/security-policy.yaml
@@ -30,12 +30,21 @@ spec:
       match:
         expr:
           expression: |
-            evaluatePreconfiguredExpr('lfi-stable')
-            || evaluatePreconfiguredExpr('rce-stable')
-            || evaluatePreconfiguredExpr('scannerdetection-stable')
-            || evaluatePreconfiguredExpr('protocolattack-stable')
-            || evaluatePreconfiguredExpr('sessionfixation-stable')
+            evaluatePreconfiguredExpr('lfi-v33-stable')
+            || evaluatePreconfiguredExpr('rfi-v33-stable')
+            || evaluatePreconfiguredExpr('rce-v33-stable')
+            || evaluatePreconfiguredExpr('methodenforcement-v33-stable')
+            || evaluatePreconfiguredExpr('scannerdetection-v33-stable')
       priority: 10000
+    - action: deny(403)
+      description: block preconfiguredWAF list - part2
+      match:
+        expr:
+          expression: |
+            evaluatePreconfiguredExpr('protocolattack-v33-stable')
+            || evaluatePreconfiguredExpr('sessionfixation-v33-stable')
+            || evaluatePreconfiguredExpr('xss-v33-stable')
+      priority: 10001
     - action: allow
       description: allow Canada
       match:


### PR DESCRIPTION
update cloud armor policy to use v33 of preconfigured waf rules. All lists are using distinct rules.

- lfi-v33-stable
- rfi-v33-stable
- rce-v33-stable
- methodenforcement-v33-stable
- scannerdetection-v33-stable
- protocolattack-v33-stable
- sessionfixation-v33-stable
- xss-v33-stable

The list below are not included in this example as they are more application specific and will be evaluated on a per application basis

- nodejs-v33-stable
- java-v33-stable
- php-v33-stable
- sqli-v33-stable
- cve-canary(Apache Log4j CVE-2021-44228)
- json-sqli-canary(JSON-formatted content SQLi)

credit to Yan Bellerose for this repository https://github.com/ybellerose/GCP-Cloud-Armor/tree/main

closes #730

![image](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/assets/85115688/143bebf0-13cc-4222-aa34-54109b41299c)
