### PR TITLE
fix config controller list - documentation #743

### DIFF
--- a/docs/landing-zone-v2/README.md
+++ b/docs/landing-zone-v2/README.md
@@ -709,7 +709,7 @@ kubectl delete gcp --all
 
 Once the resources have been deleted you can delete the config controller instance .
 
-If you have forgotten the name of the instance you can run `gcloud config controller list` to reveal the instances in your project.
+If you have forgotten the name of the instance you can run `gcloud anthos config controller list` to reveal the instances in your current project.
 
 ```shell
 gcloud anthos config controller delete instance-name --location instance-region


### PR DESCRIPTION
Test results on https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/issues/743

# before
- via https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/docs/landing-zone-v2#gitops "If you have forgotten the name of the instance you can run gcloud config controller list to reveal the instances in your project." to
"If you have forgotten the name of the instance you can run gcloud anthos config controller list to reveal the instances in your project."
```
admin_@cloudshell:~/pdt-arg (pdt-arg-kcc11)$ gcloud config controller list
ERROR: (gcloud.config) Invalid choice: 'controller'.
Maybe you meant:
  gcloud anthos
  gcloud config
```

# After - gcloud testing
- same as https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/gh446-hub/solutions/setup.sh#L203
```
admin_@cloudshell:~/pdt-arg (pdt-arg)$ gcloud config set project pdt-arg-kcc11
Updated property [core/project].
admin_@cloudshell:~/pdt-arg (pdt-arg-kcc11)$ gcloud anthos config controller list
NAME: pdt-arg
LOCATION: northamerica-northeast1
STATE: RUNNING
```

# Alternate gcloud references verified
- no delete section = ok - https://github.com/ssc-spc-ccoe-cei/gcp-tools/blob/main/scripts/bootstrap/setup-kcc.sh
- ok - https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/gh446-hub/solutions/setup.sh#L203