### PR TITLE
fix: removing data access config from gke-setup

### DIFF
--- a/solutions/gke/configconnector/gke-setup/README.md
+++ b/solutions/gke/configconnector/gke-setup/README.md
@@ -16,11 +16,11 @@ Package to prepare a service project for GKE clusters. Permissions are granted o
 |             Name             |              Value              | Type | Count |
 |------------------------------|---------------------------------|------|-------|
 | client-management-project-id | client-management-project-12345 | str  |     1 |
-| client-name                  | client1                         | str  |    50 |
+| client-name                  | client1                         | str  |    47 |
 | gke-monitoring-group         | group@example.com               | str  |     1 |
 | host-project-id              | net-host-project-12345          | str  |    10 |
 | org-id                       |                      0000000000 | str  |     3 |
-| project-id                   | project-12345                   | str  |    92 |
+| project-id                   | project-12345                   | str  |    89 |
 | project-number               |                      0000000000 | str  |     5 |
 
 ## Sub-packages
@@ -54,7 +54,6 @@ This package has no sub-packages.
 | project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-tier4-sa-artifactregistry-admin-project-id-permissions                  | client-name-projects |
 | project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | project-id-tier4-sa-tier4-secret-manager-admin-project-id-permissions              | client-name-projects |
 | project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember               | client-name-logging-sa-pubsub-admin-project-id-permissions                         | client-name-projects |
-| project-iam.yaml                            | iam.cnrm.cloud.google.com/v1beta1          | IAMAuditConfig                | project-id-data-access-log-config                                                  | client-name-projects |
 | services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-container                                                               | client-name-projects |
 | services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-containersecurity                                                       | client-name-projects |
 | services.yaml                               | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                       | project-id-anthos                                                                  | client-name-projects |
@@ -71,7 +70,6 @@ This package has no sub-packages.
 ## Resource References
 
 - [GKEHubFeature](https://cloud.google.com/config-connector/docs/reference/resource-docs/gkehub/gkehubfeature)
-- [IAMAuditConfig](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamauditconfig)
 - [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
 - [MonitoringAlertPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/monitoring/monitoringalertpolicy)
 - [MonitoringNotificationChannel](https://cloud.google.com/config-connector/docs/reference/resource-docs/monitoring/monitoringnotificationchannel)

--- a/solutions/gke/configconnector/gke-setup/project-iam.yaml
+++ b/solutions/gke/configconnector/gke-setup/project-iam.yaml
@@ -159,22 +159,4 @@ spec:
     name: project-id # kpt-set: ${project-id}
   role: roles/pubsub.admin
   member: "serviceAccount:client-name-logging-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-logging-sa@${client-management-project-id}.iam.gserviceaccount.com
----
-# Enable the Kubernetes Engine API data access log configuration on the GKE service project
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMAuditConfig
-metadata:
-  name: project-id-data-access-log-config # kpt-set: ${project-id}-data-access-log-config
-  namespace: client-name-projects # kpt-set: ${client-name}-projects
-  annotations:
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/client1-projects/Project/project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/${client-name}-projects/Project/${project-id}
-spec:
-  service: container.googleapis.com
-  auditLogConfigs:
-    - logType: ADMIN_READ
-    - logType: DATA_READ
-    - logType: DATA_WRITE
-  resourceRef:
-    kind: Project
-    name: project-id # kpt-set: ${project-id}
-    namespace: client-name-projects # kpt-set: ${client-name}-projects
+


### PR DESCRIPTION
Closes #762

As previously discussed, the choice of enabling data access logs falls onto the client. Therefore, we will be removing the data access configuration from the `gke-setup` package.