### PR TITLE
fix: adding storage admin role to logging sa

### DIFF
--- a/solutions/experimentation/core-landing-zone/README.md
+++ b/solutions/experimentation/core-landing-zone/README.md
@@ -16,10 +16,10 @@ Depends on the bootstrap procedure.
 | allowed-contact-domains       | ["@example.com"]          | array |     1 |
 | allowed-policy-domain-members | ["DIRECTORY_CUSTOMER_ID"] | array |     1 |
 | billing-id                    | AAAAAA-BBBBBB-CCCCCC      | str   |     1 |
-| logging-project-id            | logging-project-12345     | str   |    29 |
+| logging-project-id            | logging-project-12345     | str   |    32 |
 | lz-folder-id                  |                0000000000 | str   |    13 |
 | management-namespace          | config-control            | str   |    38 |
-| management-project-id         | management-project-12345  | str   |    82 |
+| management-project-id         | management-project-12345  | str   |    83 |
 | management-project-number     |                0000000000 | str   |     3 |
 | org-id                        |                0000000000 | str   |    16 |
 | retention-in-days             |                         1 | int   |     2 |
@@ -76,6 +76,7 @@ This package has no sub-packages.
 | namespaces/logging.yaml                                         | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember            | logging-sa-logadmin-permissions                                           | config-control               |
 | namespaces/logging.yaml                                         | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember            | logging-sa-monitoring-admin-management-project-id-permissions             | config-control               |
 | namespaces/logging.yaml                                         | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember            | logging-sa-monitoring-admin-logging-project-id-permissions                | projects                     |
+| namespaces/logging.yaml                                         | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember            | logging-sa-storageadmin-logging-project-id-permissions                    | projects                     |
 | namespaces/logging.yaml                                         | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy           | logging-sa-workload-identity-binding                                      | config-control               |
 | namespaces/logging.yaml                                         | v1                                            | Namespace                  | logging                                                                   |                              |
 | namespaces/logging.yaml                                         | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext     | configconnectorcontext.core.cnrm.cloud.google.com                         | logging                      |

--- a/solutions/experimentation/core-landing-zone/namespaces/logging.yaml
+++ b/solutions/experimentation/core-landing-zone/namespaces/logging.yaml
@@ -78,6 +78,24 @@ spec:
   role: roles/monitoring.admin
   member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
 ---
+# Grant GCP role Storage Admin to GCP SA on logging project
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: logging-sa-storageadmin-logging-project-id-permissions # kpt-set: logging-sa-storageadmin-${logging-project-id}-permissions
+  namespace: projects
+  annotations:
+    cnrm.cloud.google.com/project-id: logging-project-id # kpt-set: ${logging-project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    name: logging-project-id # kpt-set: ${logging-project-id}
+  # AC-3(7), AC-3, AC-16(2)
+  role: roles/storage.admin
+  member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
+---
 # K8S SA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy


### PR DESCRIPTION
Closes #775

Adding the storage admin role `roles/storage.admin` to the logging service account in experimentation/core-landing-zone.