### PR TITLE
feat: add missing storage bucket

### DIFF
--- a/solutions/experimentation/core-landing-zone/README.md
+++ b/solutions/experimentation/core-landing-zone/README.md
@@ -11,19 +11,22 @@ Depends on the bootstrap procedure.
 
 ## Setters
 
-|             Name              |           Value           | Type  | Count |
-|-------------------------------|---------------------------|-------|-------|
-| allowed-contact-domains       | ["@example.com"]          | array |     1 |
-| allowed-policy-domain-members | ["DIRECTORY_CUSTOMER_ID"] | array |     1 |
-| billing-id                    | AAAAAA-BBBBBB-CCCCCC      | str   |     1 |
-| logging-project-id            | logging-project-12345     | str   |    32 |
-| lz-folder-id                  |                0000000000 | str   |    13 |
-| management-namespace          | config-control            | str   |    38 |
-| management-project-id         | management-project-12345  | str   |    83 |
-| management-project-number     |                0000000000 | str   |     3 |
-| org-id                        |                0000000000 | str   |    16 |
-| retention-in-days             |                         1 | int   |     2 |
-| retention-locking-policy      | false                     | bool  |     2 |
+|                         Name                          |            Value             | Type  | Count |
+|-------------------------------------------------------|------------------------------|-------|-------|
+| allowed-contact-domains                               | ["@example.com"]             | array |     1 |
+| allowed-policy-domain-members                         | ["DIRECTORY_CUSTOMER_ID"]    | array |     1 |
+| billing-id                                            | AAAAAA-BBBBBB-CCCCCC         | str   |     1 |
+| logging-project-id                                    | logging-project-12345        | str   |    34 |
+| lz-folder-id                                          |                   0000000000 | str   |    13 |
+| management-namespace                                  | config-control               | str   |    38 |
+| management-project-id                                 | management-project-12345     | str   |    83 |
+| management-project-number                             |                   0000000000 | str   |     3 |
+| org-id                                                |                   0000000000 | str   |    16 |
+| retention-in-days                                     |                            1 | int   |     2 |
+| retention-locking-policy                              | false                        | bool  |     2 |
+| security-incident-log-bucket                          | security-incident-log-bucket | str   |     1 |
+| security-incident-log-bucket-retention-in-seconds     |                        86400 | int   |     1 |
+| security-incident-log-bucket-retention-locking-policy | false                        | bool  |     1 |
 
 ## Sub-packages
 
@@ -36,6 +39,7 @@ This package has no sub-packages.
 | lz-folder/audits/folder.yaml                                    | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                     | audits                                                                    | hierarchy                    |
 | lz-folder/audits/logging-project/cloud-logging-buckets.yaml     | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogBucket           | security-log-bucket                                                       | logging                      |
 | lz-folder/audits/logging-project/cloud-logging-buckets.yaml     | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogBucket           | platform-and-component-log-bucket                                         | logging                      |
+| lz-folder/audits/logging-project/cloud-storage-buckets.yaml     | storage.cnrm.cloud.google.com/v1beta1         | StorageBucket              | security-incident-log-bucket                                              | logging                      |
 | lz-folder/audits/logging-project/monitoring/metrics-scope.yaml  | monitoring.cnrm.cloud.google.com/v1beta1      | MonitoringMonitoredProject | management-project-id                                                     | logging                      |
 | lz-folder/audits/logging-project/project-iam.yaml               | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy           | security-log-bucket-writer-permissions                                    | projects                     |
 | lz-folder/audits/logging-project/project-iam.yaml               | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy           | platform-and-component-log-bucket-writer-permissions                      | projects                     |
@@ -139,6 +143,7 @@ This package has no sub-packages.
 - [ResourceManagerPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/resourcemanagerpolicy)
 - [RoleBinding](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#rolebinding-v1-rbac-authorization-k8s-io)
 - [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
+- [StorageBucket](https://cloud.google.com/config-connector/docs/reference/resource-docs/storage/storagebucket)
 
 ## Usage
 

--- a/solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/cloud-storage-buckets.yaml
+++ b/solutions/experimentation/core-landing-zone/lz-folder/audits/logging-project/cloud-storage-buckets.yaml
@@ -1,0 +1,36 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Cloud Storage bucket to store logs related to security incidents
+# https://cloud.google.com/logging/docs/routing/copy-logs
+# AU-9, AU-11 - Storage bucket created to hold logs related to security incidents (AU-11). Log is protected from modification and deletion (AU-9)
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  name: security-incident-log-bucket # kpt-set: ${security-incident-log-bucket}
+  namespace: logging
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id} # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${logging-project-id}
+    cnrm.cloud.google.com/project-id: logging-project-id # kpt-set: ${logging-project-id}
+spec:
+  # enable autoclass
+  # https://cloud.google.com/storage/docs/autoclass
+  autoclass:
+    enabled: true
+  location: northamerica-northeast1
+  publicAccessPrevention: "enforced"
+  uniformBucketLevelAccess: true
+  # AU-9
+  retentionPolicy:
+    isLocked: false # kpt-set: ${security-incident-log-bucket-retention-locking-policy}
+    retentionPeriod: 86400 # kpt-set: ${security-incident-log-bucket-retention-in-seconds}

--- a/solutions/experimentation/core-landing-zone/setters.yaml
+++ b/solutions/experimentation/core-landing-zone/setters.yaml
@@ -93,6 +93,16 @@ data:
   retention-locking-policy: "false"
   retention-in-days: "1"
   #
+  # Retention settings for Cloud Storage bucket to store logs related to security incidents
+  # Events and logs associated with a security incident must be kept for at least 2 years
+  # Set the lock mechanism on the bucket to: true or false
+  # After a retention policy is locked (true), you can't delete the bucket until every log in the bucket has fulfilled the bucket's retention period
+  # AU-9 PROTECTION OF AUDIT INFORMATION
+  # AU-11 AUDIT RECORD RETENTION
+  # customization: The values below must be modified to locked: true and retentionSeconds: 63072000 (730 days) in a Production setting to implement above mentioned security controls.
+  security-incident-log-bucket-retention-locking-policy: "false"
+  security-incident-log-bucket-retention-in-seconds: "86400"
+  #
   ##########################
   # End of Configurations
   ##########################

--- a/solutions/experimentation/core-landing-zone/setters.yaml
+++ b/solutions/experimentation/core-landing-zone/setters.yaml
@@ -76,6 +76,12 @@ data:
   #
   logging-project-id: logging-project-12345
   #
+  # Storage buckets
+  # Security incident log bucket
+  # Bucket names must be globally unique across all of GCP
+  # customization: required
+  security-incident-log-bucket: security-incident-log-bucket-12345
+  #
   # Retention settings
   # Set the number of days to retain logs in Cloud Logging buckets
   # Set the lock mechanism on the bucket to: true or false


### PR DESCRIPTION
Closes #780 

Add missing security-incident-log-bucket to the experimentation core-landing-zone solution.

Permissions for bucket added via previous issue #775.