### PR TITLE
fix: validate-solutions fetch depth

### DIFF
--- a/.github/workflows/validate-solutions.yaml
+++ b/.github/workflows/validate-solutions.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: 'Validate Solutions Packages'
         run: |


### PR DESCRIPTION
closes #792

add `fetch-depth: 0` to validate-solutions checkout action