### PR TITLE
Add constraints/compute.restrictCloudNATUsage policy override for hub-env fortigate project - to allow NAT to deploy #837

### DIFF
--- a/solutions/project/hub-env/org-policies/exceptions/compute-restrict-cloud-nat-usage-except-hub-project.yaml
+++ b/solutions/project/hub-env/org-policies/exceptions/compute-restrict-cloud-nat-usage-except-hub-project.yaml
@@ -1,0 +1,43 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########
+#
+# GCP Organization Policies
+# Org policies that correspond with a Guardrail will contain a label indicating what Guardrails it helps in enforcing
+# https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints
+#
+# Constraint: constraints/compute.restrictCloudNATUsage
+#
+# This list constraint defines the set of subnetworks that are allowed to use Cloud NAT.
+#
+# This exception is for the host project as it requires use of Cloud NAT.
+#
+#########
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: ResourceManagerPolicy
+metadata:
+  name: compute-restrict-cloud-nat-usage-except2-hub-project-id # kpt-set: compute-restrict-cloud-nat-usage-except2-${hub-project-id}
+  namespace: policies
+  annotations:
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/hub-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${hub-project-id}
+  labels:
+    guardrail: "false"
+spec:
+  constraint: "constraints/compute.restrictCloudNATUsage"
+  listPolicy:
+    allow:
+      values:
+        - under:projects/PROJECT_ID # kpt-set: under:projects/${hub-project-id}
+  projectRef:
+    external: "0000000000" # kpt-set: ${hub-project-id}


### PR DESCRIPTION
see extended live testing on a deployed hub for #766 under #837

gcp
<img width="843" alt="Screenshot 2024-02-21 at 17 08 15" src="https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/assets/24765473/33f774d4-ea29-48f8-b0b7-831ae126b58c">

gke object
<img width="1498" alt="Screenshot 2024-02-21 at 17 09 55" src="https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/assets/24765473/235e3d5f-e13e-41b9-83e7-1782f30506f7">
