### PR TITLE
feat: distinct VPC host prep core-landing-zone

### DIFF
--- a/solutions/core-landing-zone/README.md
+++ b/solutions/core-landing-zone/README.md
@@ -22,8 +22,8 @@ Attention, validate impact with CCCS Cloud Based Sensors before implementing any
 | allowed-trusted-image-projects                        | ["projects/cos-cloud"]                  | array |     1 |
 | allowed-vpc-peering                                   | ["under:organizations/ORGANIZATION_ID"] | array |     1 |
 | billing-id                                            | AAAAAA-BBBBBB-CCCCCC                    | str   |     2 |
+| core-dns-project-id                                   | dns-project-12345                       | str   |     8 |
 | dns-name                                              | example.com.                            | str   |     1 |
-| dns-project-id                                        | dns-project-12345                       | str   |     8 |
 | logging-project-id                                    | logging-project-12345                   | str   |    36 |
 | lz-folder-id                                          |                              0000000000 | str   |    14 |
 | management-namespace                                  | config-control                          | str   |    48 |
@@ -62,9 +62,9 @@ This package has no sub-packages.
 | lz-folder/clients/folder.yaml                                                         | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                     | clients                                                                   | hierarchy                    |
 | lz-folder/services/folder-sink.yaml                                                   | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink             | platform-and-component-services-log-sink                                  | logging                      |
 | lz-folder/services/folder.yaml                                                        | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                     | services                                                                  | hierarchy                    |
-| lz-folder/services-infrastructure/dns-project/dns.yaml                                | dns.cnrm.cloud.google.com/v1beta1             | DNSManagedZone             | dns-project-id-standard-core-public-dns                                   | networking                   |
-| lz-folder/services-infrastructure/dns-project/project.yaml                            | resourcemanager.cnrm.cloud.google.com/v1beta1 | Project                    | dns-project-id                                                            | projects                     |
-| lz-folder/services-infrastructure/dns-project/services.yaml                           | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                    | dns-project-id-dns                                                        | projects                     |
+| lz-folder/services-infrastructure/dns-project/dns.yaml                                | dns.cnrm.cloud.google.com/v1beta1             | DNSManagedZone             | core-dns-project-id-standard-core-public-dns                              | networking                   |
+| lz-folder/services-infrastructure/dns-project/project.yaml                            | resourcemanager.cnrm.cloud.google.com/v1beta1 | Project                    | core-dns-project-id                                                       | projects                     |
+| lz-folder/services-infrastructure/dns-project/services.yaml                           | serviceusage.cnrm.cloud.google.com/v1beta1    | Service                    | core-dns-project-id-dns                                                   | projects                     |
 | lz-folder/services-infrastructure/folder-sink.yaml                                    | logging.cnrm.cloud.google.com/v1beta1         | LoggingLogSink             | platform-and-component-services-infra-log-sink                            | logging                      |
 | lz-folder/services-infrastructure/folder.yaml                                         | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder                     | services-infrastructure                                                   | hierarchy                    |
 | mgmt-project/org-policies/compute-disable-serial-port-logging-except-mgt-project.yaml | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy      | compute-disable-serial-port-logging-except-mgt-project                    | policies                     |

--- a/solutions/core-landing-zone/lz-folder/services-infrastructure/dns-project/dns.yaml
+++ b/solutions/core-landing-zone/lz-folder/services-infrastructure/dns-project/dns.yaml
@@ -19,11 +19,11 @@
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSManagedZone
 metadata:
-  name: dns-project-id-standard-core-public-dns # kpt-set: ${dns-project-id}-standard-core-public-dns
+  name: core-dns-project-id-standard-core-public-dns # kpt-set: ${core-dns-project-id}-standard-core-public-dns
   namespace: networking
   annotations:
-    cnrm.cloud.google.com/project-id: dns-project-id # kpt-set: ${dns-project-id}
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/dns-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${dns-project-id}
+    cnrm.cloud.google.com/project-id: core-dns-project-id # kpt-set: ${core-dns-project-id}
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/core-dns-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${core-dns-project-id}
 spec:
   description: "standard core public dns zone"
   resourceID: standard-core-public-dns

--- a/solutions/core-landing-zone/lz-folder/services-infrastructure/dns-project/project.yaml
+++ b/solutions/core-landing-zone/lz-folder/services-infrastructure/dns-project/project.yaml
@@ -16,13 +16,13 @@
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: Project
 metadata:
-  name: dns-project-id # kpt-set: ${dns-project-id}
+  name: core-dns-project-id # kpt-set: ${core-dns-project-id}
   namespace: projects
   annotations:
     cnrm.cloud.google.com/auto-create-network: "false"
     config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/hierarchy/Folder/services-infrastructure # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/hierarchy/Folder/services-infrastructure
 spec:
-  name: dns-project-id # kpt-set: ${dns-project-id}
+  name: core-dns-project-id # kpt-set: ${core-dns-project-id}
   billingAccountRef:
     external: "AAAAAA-BBBBBB-CCCCCC" # kpt-set: ${billing-id}
   folderRef:

--- a/solutions/core-landing-zone/lz-folder/services-infrastructure/dns-project/services.yaml
+++ b/solutions/core-landing-zone/lz-folder/services-infrastructure/dns-project/services.yaml
@@ -16,12 +16,12 @@
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
-  name: dns-project-id-dns # kpt-set: ${dns-project-id}-dns
+  name: core-dns-project-id-dns # kpt-set: ${core-dns-project-id}-dns
   namespace: projects
   annotations:
     cnrm.cloud.google.com/disable-on-destroy: "false"
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/dns-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${dns-project-id}
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/core-dns-project-id # kpt-set: resourcemanager.cnrm.cloud.google.com/namespaces/projects/Project/${core-dns-project-id}
 spec:
   resourceID: dns.googleapis.com
   projectRef:
-    external: dns-project-id # kpt-set: ${dns-project-id}
+    external: core-dns-project-id # kpt-set: ${core-dns-project-id}

--- a/solutions/core-landing-zone/securitycontrols.md
+++ b/solutions/core-landing-zone/securitycontrols.md
@@ -304,8 +304,8 @@
 |AU-11|./setters.yaml|setters|
 |AU-12|./lz-folder/audits/logging-project/project-sink.yaml|logging-project-id-data-access-sink|
 |AU-12|./lz-folder/audits/logging-project/project-sink.yaml|logging-project-id-data-access-sink|
-|AU-12|./lz-folder/services-infrastructure/dns-project/dns.yaml|dns-project-id-standard-core-public-dns|
-|AU-12|./lz-folder/services-infrastructure/dns-project/dns.yaml|dns-project-id-standard-core-public-dns|
+|AU-12|./lz-folder/services-infrastructure/dns-project/dns.yaml|core-dns-project-id-standard-core-public-dns|
+|AU-12|./lz-folder/services-infrastructure/dns-project/dns.yaml|core-dns-project-id-standard-core-public-dns|
 |AU-12|./lz-folder/services-infrastructure/folder-sink.yaml|platform-and-component-services-infra-log-sink|
 |AU-12|./lz-folder/services-infrastructure/folder-sink.yaml|platform-and-component-services-infra-log-sink|
 |AU-12|./lz-folder/services/folder-sink.yaml|platform-and-component-services-log-sink|
@@ -436,8 +436,8 @@
 |AU-9(4)|./lz-folder/audits/logging-project/cloud-storage-buckets.yaml|security-incident-log-bucket|
 |IA-1|./org/org-policies/iam-disable-service-account-key-creation.yaml|iam-disable-service-account-key-creation|
 |IA-1|./org/org-policies/iam-disable-service-account-key-upload.yaml|iam-disable-service-account-key-upload|
-|SC-20|./lz-folder/services-infrastructure/dns-project/dns.yaml|dns-project-id-standard-core-public-dns|
-|SC-20|./lz-folder/services-infrastructure/dns-project/dns.yaml|dns-project-id-standard-core-public-dns|
+|SC-20|./lz-folder/services-infrastructure/dns-project/dns.yaml|core-dns-project-id-standard-core-public-dns|
+|SC-20|./lz-folder/services-infrastructure/dns-project/dns.yaml|core-dns-project-id-standard-core-public-dns|
 |SI-4|./lz-folder/audits/logging-project/cloud-logging-buckets.yaml|platform-and-component-log-bucket|
 |SI-4|./lz-folder/audits/logging-project/cloud-logging-buckets.yaml|security-log-bucket|
 |SI-4|./lz-folder/audits/logging-project/cloud-logging-buckets.yaml|security-log-bucket|

--- a/solutions/core-landing-zone/setters.yaml
+++ b/solutions/core-landing-zone/setters.yaml
@@ -149,7 +149,7 @@ data:
   #
   # project id for the dns project to be created, following rules and conventions
   # customization: required
-  dns-project-id: dns-project-12345
+  core-dns-project-id: dns-project-12345
   #
   # Core Landing Zone fqdn. The "dns-name" must end with a "."
   # dns-name needs needs to receive delegation from the upper level of the domain example.com.


### PR DESCRIPTION
in preparation for feature #883

**NOTICE**: setters have been modified

- rename the `dns-project-id` setter to `core-dns-project-id` to avoid confusion with the upcoming new dns project in the client-landing-zone