### PR TITLE
feat: distinct VPC host prep gke-defaults

### DIFF
--- a/solutions/gke/configconnector/gke-defaults/README.md
+++ b/solutions/gke/configconnector/gke-defaults/README.md
@@ -27,7 +27,6 @@ loaded in the config controller.
 | dns-project-id   | dns-project-id            | str   |     1 |
 | domains          | [example.com]             | array |     1 |
 | gateway-name     | gateway-name              | str   |     3 |
-| host-project-id  | host-project-12345        | str   |     0 |
 | metadata-name    | metadata-name             | str   |     1 |
 | project-id       | project-12345             | str   |    12 |
 | spec-name        | dns-name                  | str   |     1 |

--- a/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/setters.yaml
+++ b/solutions/gke/configconnector/gke-defaults/gateway-setup/dns/setters.yaml
@@ -29,8 +29,7 @@ data:
   # Client
   ##########################
   #
-  # Project that has the public dns zone.
-  # Usually the client host project that was created by the client-landing-zone package
+  # Project that has the client's public dns zone, created by the client-landing-zone package.
   # customization: required
   dns-project-id: dns-project-12345
   #

--- a/solutions/gke/configconnector/gke-defaults/setters.yaml
+++ b/solutions/gke/configconnector/gke-defaults/setters.yaml
@@ -37,10 +37,6 @@ data:
   # customization: required
   team-gkeviewer: 'group:client1@example.com'
   #
-  # the host project for this client created in client-landing-zone package deployment
-  # customization: required
-  host-project-id: host-project-12345
-  #
   ##########################
   # Project
   ##########################


### PR DESCRIPTION
in preparation for feature #883

**NOTICE**: setters have been modified

**`gke-defaults`** package:
  - update setter instructions for dns-project-id
  - cleanup the host-project-id setter which was not used