### PR TITLE
feat: distinct VPC host prep gke-cluster-autopilot BREAKING CHANGE

### DIFF
--- a/solutions/gke/configconnector/gke-cluster-autopilot/README.md
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/README.md
@@ -61,17 +61,18 @@ To fix this, you update the `root-sync` resource to include the override section
 
 |              Name               |                        Value                         | Type  | Count |
 |---------------------------------|------------------------------------------------------|-------|-------|
+| classification                  | nonp                                                 | str   |     3 |
 | client-name                     | client1                                              | str   |    18 |
 | cluster-name                    | autopilot1-gke                                       | str   |    36 |
 | gke-to-azdo-priority            |                                                 2000 | int   |     1 |
 | gke-to-docker-priority          |                                                 2002 | int   |     1 |
 | gke-to-github-priority          |                                                 2001 | int   |     1 |
-| host-project-id                 | host-project-12345                                   | str   |     6 |
-| host-project-vpc                | host-project-vpc                                     | str   |     2 |
+| host-project-id                 | host-project-12345                                   | str   |     8 |
 | location                        | northamerica-northeast1                              | str   |     5 |
 | master-authorized-networks-cidr | [cidrBlock: 10.1.1.5/32displayName: gke-admin-proxy] | array |     1 |
 | masterIpv4CidrBlock             | 192.168.0.0/28                                       | str   |     1 |
 | masterIpv4Range                 | ["192.168.0.0/28"]                                   | array |     0 |
+| network-connectivity-profile    | standard                                             | str   |     6 |
 | networktags                     |                                                      | str   |     0 |
 | networktags-enabled             | false                                                | str   |     0 |
 | podIpv4Range                    | ["172.16.0.0/23"]                                    | array |     1 |
@@ -91,27 +92,27 @@ This package has no sub-packages.
 
 ## Resources
 
-|                      File                       |               APIVersion                |           Kind            |                                Name                                 |    Namespace     |
-|-------------------------------------------------|-----------------------------------------|---------------------------|---------------------------------------------------------------------|------------------|
-| application-infrastructure-folder/firewall.yaml | compute.cnrm.cloud.google.com/v1beta1   | ComputeFirewallPolicyRule | project-id-cluster-name-egress-allow-azdo                           | project-id-tier3 |
-| application-infrastructure-folder/firewall.yaml | compute.cnrm.cloud.google.com/v1beta1   | ComputeFirewallPolicyRule | project-id-cluster-name-egress-allow-github                         | project-id-tier3 |
-| application-infrastructure-folder/firewall.yaml | compute.cnrm.cloud.google.com/v1beta1   | ComputeFirewallPolicyRule | project-id-cluster-name-egress-allow-docker                         | project-id-tier3 |
-| gke.yaml                                        | container.cnrm.cloud.google.com/v1beta1 | ContainerCluster          | cluster-name                                                        | project-id-tier3 |
-| gkehub-featuremembership-acm.yaml               | gkehub.cnrm.cloud.google.com/v1beta1    | GKEHubFeatureMembership   | cluster-name-acm-hubfeaturemembership                               | project-id-tier3 |
-| gkehub-membership.yaml                          | gkehub.cnrm.cloud.google.com/v1beta1    | GKEHubMembership          | cluster-name                                                        | project-id-tier3 |
-| host-project/firewall.yaml                      | compute.cnrm.cloud.google.com/v1beta1   | ComputeFirewall           | project-id-cluster-name-lb-health-check                             |                  |
-| host-project/subnet.yaml                        | compute.cnrm.cloud.google.com/v1beta1   | ComputeSubnetwork         | project-id-cluster-name-snet                                        |                  |
-| kms.yaml                                        | kms.cnrm.cloud.google.com/v1beta1       | KMSKeyRing                | cluster-name-kmskeyring                                             | project-id-tier3 |
-| kms.yaml                                        | kms.cnrm.cloud.google.com/v1beta1       | KMSCryptoKey              | cluster-name-etcd-key                                               | project-id-tier3 |
-| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMServiceAccount         | cluster-name-sa                                                     | project-id-tier3 |
-| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-logwriter-permissions                               | project-id-tier3 |
-| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-metricwriter-permissions                            | project-id-tier3 |
-| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-monitoring-viewer-permissions                       | project-id-tier3 |
-| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-storage-object-viewer-permissions                   | project-id-tier3 |
-| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-stackdriver-metadata-writer-permissions             | project-id-tier3 |
-| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-artifactregistry-reader-permissions                 | project-id-tier3 |
-| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-secretmanager-secretaccessor-permissions            | project-id-tier3 |
-| service-account.yaml                            | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | project-id-tier3-sa-serviceaccount-user-cluster-name-sa-permissions | project-id-tier3 |
+|                     File                      |               APIVersion                |           Kind            |                                Name                                 |    Namespace     |
+|-----------------------------------------------|-----------------------------------------|---------------------------|---------------------------------------------------------------------|------------------|
+| app-infra-classification-folder/firewall.yaml | compute.cnrm.cloud.google.com/v1beta1   | ComputeFirewallPolicyRule | project-id-cluster-name-egress-allow-azdo                           | project-id-tier3 |
+| app-infra-classification-folder/firewall.yaml | compute.cnrm.cloud.google.com/v1beta1   | ComputeFirewallPolicyRule | project-id-cluster-name-egress-allow-github                         | project-id-tier3 |
+| app-infra-classification-folder/firewall.yaml | compute.cnrm.cloud.google.com/v1beta1   | ComputeFirewallPolicyRule | project-id-cluster-name-egress-allow-docker                         | project-id-tier3 |
+| gke.yaml                                      | container.cnrm.cloud.google.com/v1beta1 | ContainerCluster          | cluster-name                                                        | project-id-tier3 |
+| gkehub-featuremembership-acm.yaml             | gkehub.cnrm.cloud.google.com/v1beta1    | GKEHubFeatureMembership   | cluster-name-acm-hubfeaturemembership                               | project-id-tier3 |
+| gkehub-membership.yaml                        | gkehub.cnrm.cloud.google.com/v1beta1    | GKEHubMembership          | cluster-name                                                        | project-id-tier3 |
+| host-project/firewall.yaml                    | compute.cnrm.cloud.google.com/v1beta1   | ComputeFirewall           | project-id-cluster-name-lb-health-check                             |                  |
+| host-project/subnet.yaml                      | compute.cnrm.cloud.google.com/v1beta1   | ComputeSubnetwork         | project-id-cluster-name-snet                                        |                  |
+| kms.yaml                                      | kms.cnrm.cloud.google.com/v1beta1       | KMSKeyRing                | cluster-name-kmskeyring                                             | project-id-tier3 |
+| kms.yaml                                      | kms.cnrm.cloud.google.com/v1beta1       | KMSCryptoKey              | cluster-name-etcd-key                                               | project-id-tier3 |
+| service-account.yaml                          | iam.cnrm.cloud.google.com/v1beta1       | IAMServiceAccount         | cluster-name-sa                                                     | project-id-tier3 |
+| service-account.yaml                          | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-logwriter-permissions                               | project-id-tier3 |
+| service-account.yaml                          | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-metricwriter-permissions                            | project-id-tier3 |
+| service-account.yaml                          | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-monitoring-viewer-permissions                       | project-id-tier3 |
+| service-account.yaml                          | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-storage-object-viewer-permissions                   | project-id-tier3 |
+| service-account.yaml                          | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-stackdriver-metadata-writer-permissions             | project-id-tier3 |
+| service-account.yaml                          | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-artifactregistry-reader-permissions                 | project-id-tier3 |
+| service-account.yaml                          | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | cluster-name-sa-secretmanager-secretaccessor-permissions            | project-id-tier3 |
+| service-account.yaml                          | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember           | project-id-tier3-sa-serviceaccount-user-cluster-name-sa-permissions | project-id-tier3 |
 
 ## Resource References
 

--- a/solutions/gke/configconnector/gke-cluster-autopilot/app-infra-classification-folder/firewall.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/app-infra-classification-folder/firewall.yaml
@@ -31,7 +31,7 @@ spec:
   # AU-12
   enableLogging: true
   firewallPolicyRef:
-    name: client-name-standard-applications-infrastructure-fwpol # kpt-set: ${client-name}-standard-applications-infrastructure-fwpol
+    name: client-name-network-connectivity-profile-app-infra-classification-fwpol # kpt-set: ${client-name}-${network-connectivity-profile}-app-infra-${classification}-fwpol
     namespace: client-name-networking # kpt-set: ${client-name}-networking
   match:
     srcIPRanges: # kpt-set: ${primaryIpv4Range}
@@ -63,7 +63,7 @@ spec:
   # AU-12
   enableLogging: true
   firewallPolicyRef:
-    name: client-name-standard-applications-infrastructure-fwpol # kpt-set: ${client-name}-standard-applications-infrastructure-fwpol
+    name: client-name-network-connectivity-profile-app-infra-classification-fwpol # kpt-set: ${client-name}-${network-connectivity-profile}-app-infra-${classification}-fwpol
     namespace: client-name-networking # kpt-set: ${client-name}-networking
   match:
     srcIPRanges: # kpt-set: ${primaryIpv4Range}
@@ -95,7 +95,7 @@ spec:
   # AU-12
   enableLogging: true
   firewallPolicyRef:
-    name: client-name-standard-applications-infrastructure-fwpol # kpt-set: ${client-name}-standard-applications-infrastructure-fwpol
+    name: client-name-network-connectivity-profile-app-infra-classification-fwpol # kpt-set: ${client-name}-${network-connectivity-profile}-app-infra-${classification}-fwpol
     namespace: client-name-networking # kpt-set: ${client-name}-networking
   match:
     srcIPRanges: # kpt-set: ${primaryIpv4Range}

--- a/solutions/gke/configconnector/gke-cluster-autopilot/gke.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/gke.yaml
@@ -75,7 +75,7 @@ spec:
     enableComponents:
       - "SYSTEM_COMPONENTS"
   networkRef:
-    name: host-project-vpc # kpt-set: ${host-project-vpc}
+    name: host-project-id-global-network-connectivity-profile-vpc # kpt-set: ${host-project-id}-global-${network-connectivity-profile}-vpc
     namespace: client-name-networking # kpt-set: ${client-name}-networking
   networkingMode: VPC_NATIVE
   nodePoolAutoConfig:

--- a/solutions/gke/configconnector/gke-cluster-autopilot/host-project/firewall.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/host-project/firewall.yaml
@@ -25,7 +25,7 @@ spec:
   allow:
     - protocol: tcp
   networkRef:
-    name: host-project-id-global-standard-vpc # kpt-set: ${host-project-id}-global-standard-vpc
+    name: host-project-id-global-network-connectivity-profile-vpc # kpt-set: ${host-project-id}-global-${network-connectivity-profile}-vpc
     namespace: client-name-networking # kpt-set: ${client-name}-networking
   sourceRanges:
     - "35.191.0.0/16"

--- a/solutions/gke/configconnector/gke-cluster-autopilot/host-project/subnet.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/host-project/subnet.yaml
@@ -45,7 +45,7 @@ spec:
   description: GKE Subnet
   privateIpGoogleAccess: true
   networkRef:
-    name: host-project-vpc # kpt-set: ${host-project-vpc}
+    name: host-project-id-global-network-connectivity-profile-vpc # kpt-set: ${host-project-id}-global-${network-connectivity-profile}-vpc
     namespace: client-name-networking # kpt-set: ${client-name}-networking
   # AU-12
   logConfig:

--- a/solutions/gke/configconnector/gke-cluster-autopilot/securitycontrols.md
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/securitycontrols.md
@@ -52,10 +52,10 @@
 |AC-4|./gke.yaml|cluster-name|
 |AC-4|./host-project/subnet.yaml|project-id-cluster-name-snet|
 |AC-4(21)|./host-project/subnet.yaml|project-id-cluster-name-snet|
-|AU-12|./application-infrastructure-folder/firewall.yaml|project-id-cluster-name-egress-allow-azdo|
-|AU-12|./application-infrastructure-folder/firewall.yaml|project-id-cluster-name-egress-allow-azdo|
-|AU-12|./application-infrastructure-folder/firewall.yaml|project-id-cluster-name-egress-allow-docker|
-|AU-12|./application-infrastructure-folder/firewall.yaml|project-id-cluster-name-egress-allow-github|
+|AU-12|./app-infra-classification-folder/firewall.yaml|project-id-cluster-name-egress-allow-azdo|
+|AU-12|./app-infra-classification-folder/firewall.yaml|project-id-cluster-name-egress-allow-azdo|
+|AU-12|./app-infra-classification-folder/firewall.yaml|project-id-cluster-name-egress-allow-docker|
+|AU-12|./app-infra-classification-folder/firewall.yaml|project-id-cluster-name-egress-allow-github|
 |AU-12|./gke.yaml|cluster-name|
 |AU-12|./gke.yaml|cluster-name|
 |AU-12|./host-project/firewall.yaml|project-id-cluster-name-lb-health-check|
@@ -75,9 +75,9 @@
 |SC-28(1)|./gke.yaml|cluster-name|
 |SC-7|./gke.yaml|cluster-name|
 |SC-7|./gke.yaml|cluster-name|
-|SC-7(9)|./application-infrastructure-folder/firewall.yaml|project-id-cluster-name-egress-allow-azdo|
-|SC-7(9)|./application-infrastructure-folder/firewall.yaml|project-id-cluster-name-egress-allow-azdo|
-|SC-7(9)|./application-infrastructure-folder/firewall.yaml|project-id-cluster-name-egress-allow-docker|
-|SC-7(9)|./application-infrastructure-folder/firewall.yaml|project-id-cluster-name-egress-allow-github|
+|SC-7(9)|./app-infra-classification-folder/firewall.yaml|project-id-cluster-name-egress-allow-azdo|
+|SC-7(9)|./app-infra-classification-folder/firewall.yaml|project-id-cluster-name-egress-allow-azdo|
+|SC-7(9)|./app-infra-classification-folder/firewall.yaml|project-id-cluster-name-egress-allow-docker|
+|SC-7(9)|./app-infra-classification-folder/firewall.yaml|project-id-cluster-name-egress-allow-github|
 
 <!-- END OF SECURITY CONTROLS LIST -->

--- a/solutions/gke/configconnector/gke-cluster-autopilot/setters.yaml
+++ b/solutions/gke/configconnector/gke-cluster-autopilot/setters.yaml
@@ -38,9 +38,17 @@ data:
   ##########################
   #
   # The project id that was created by the client-project-setup.
-  # This id will also becomes the Anthos Fleet id
+  # The GKE cluster will be deployed in this project and the project id will also become the Anthos Fleet id
   # customization: required
   project-id: project-12345
+  #
+  # the classification of the project, accepted values are: 'pbmm' OR 'nonp' (unclassified)
+  # customization: required
+  classification: nonp
+  #
+  # the network connectivity profile of the project, accepted values are: 'standard' OR 'sc2g' (future releases)
+  # customization: optional
+  network-connectivity-profile: standard
   #
   ##########################
   # Network Host Project
@@ -49,11 +57,6 @@ data:
   # the host project for this client created in client-landing-zone package deployment
   # customization: required
   host-project-id: host-project-12345
-  #
-  # VPC to deploy the subnet, the value must match the kubernetes resources 'metadata.name'
-  # created in client-landing-zone package deployment
-  # customization: required
-  host-project-vpc: host-project-vpc
   #
   ##########################
   # GKE
@@ -124,6 +127,11 @@ data:
   networktags-enabled: false
   networktags:
     - ids
+  #
+  # The group to enable Google groups for GKE RBAC as described in the link below.
+  # The 'gke-security-groups@' must NOT be edited, only the domain.  The group needs to be created manually.
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/google-groups-rbac
+  # customization: required
   security-group: gke-security-groups@<yourdomain.com>
   #
   ##########################


### PR DESCRIPTION
**BREAKING CHANGE**
the firewall policies in this package will only work with the latest "distinct host project" design

in preparation for feature #883

**NOTICE**: setters have been modified

**`gke-cluster-autopilot`** package:
  - firewall policy rules in `application-infrastructure-folder/`: folder renamed and resources updated to reference (spec.firewallPolicyRef) the proper "classification" policy.
  - refactor setters with a similar approach to client-project-setup, to be able to update references based on classification
  - standardize how `networkRef` reference a network
