### PR TITLE
feat: distinct VPC host prep examples

### DIFF
--- a/examples/landing-zone-v2/configconnector/tier3/dns/dns.yaml
+++ b/examples/landing-zone-v2/configconnector/tier3/dns/dns.yaml
@@ -19,7 +19,7 @@ kind: DNSRecordSet
 metadata:
   name: workload-name-client-name-standard-core-public-dns-a-rset # kpt-set: workload-name-${client-name}-standard-core-public-dns-a-rset
   annotations:
-    cnrm.cloud.google.com/project-id: host-project-id # kpt-set: ${host-project-id}
+    cnrm.cloud.google.com/project-id: dns-project-id # kpt-set: ${dns-project-id}
 spec:
   name: "dns-name" # kpt-set: ${dns-name}
   type: "A"

--- a/examples/landing-zone-v2/configconnector/tier3/firewall-policy-rules/allow-egress-fqdns.yaml
+++ b/examples/landing-zone-v2/configconnector/tier3/firewall-policy-rules/allow-egress-fqdns.yaml
@@ -26,10 +26,12 @@ spec:
   disabled: false
   # AU-12
   enableLogging: true
+  # edit reference to nonp or pbmm folder accordingly
   firewallPolicyRef:
-    name: client-name-standard-applications-infrastructure-fwpol # kpt-set: ${client-name}-standard-applications-infrastructure-fwpol
+    name: client-name-standard-app-infra-nonp-fwpol # kpt-set: ${client-name}-standard-app-infra-nonp-fwpol
     namespace: client-name-networking # kpt-set: ${client-name}-networking
   match:
+    # edit protocol and ports accordingly
     layer4Configs:
       - ipProtocol: "tcp"
         ports:
@@ -41,5 +43,5 @@ spec:
     # add a list of destination fqdns below
     destFqdns:
       - "example.com"
-  # IMPORTANT to set a proper priority, each project should have a reserved range
+  # IMPORTANT to set a proper priority, no duplicates allowed on the same policy, each project should have a reserved range
   priority: 5050


### PR DESCRIPTION
in preparation for feature #883

update for examples
- **`dns`**:
  - update setter to use dns-project-id instead of host-project-id
- **`firewall-policy-rules`**:
  - edit spec.firewallPolicyRef to reference the policy on the "classification" folder