### PR TITLE
experimentation: allow client-folder display name of the experimentation client landing zone to be customizable

### DIFF
--- a/solutions/experimentation/client-landing-zone/README.md
+++ b/solutions/experimentation/client-landing-zone/README.md
@@ -12,13 +12,14 @@ Package to create a client's folder hierarchy and logging resources.
 
 ## Setters
 
-|           Name           |           Value           | Type | Count |
-|--------------------------|---------------------------|------|-------|
-| client-folderviewer      | group:client1@example.com | str  |     1 |
-| client-name              | client1                   | str  |    13 |
-| logging-project-id       | logging-project-12345     | str  |     4 |
-| retention-in-days        |                         1 | int  |     1 |
-| retention-locking-policy | false                     | bool |     1 |
+|            Name            |           Value            | Type | Count |
+|----------------------------|----------------------------|------|-------|
+| client-folder-display-name | client-folder-display-name | str  |     1 |
+| client-folderviewer        | group:client1@example.com  | str  |     1 |
+| client-name                | client1                    | str  |    12 |
+| logging-project-id         | logging-project-12345      | str  |     4 |
+| retention-in-days          |                          1 | int  |     1 |
+| retention-locking-policy   | false                      | bool |     1 |
 
 ## Sub-packages
 

--- a/solutions/experimentation/client-landing-zone/client-folder/folder.yaml
+++ b/solutions/experimentation/client-landing-zone/client-folder/folder.yaml
@@ -18,6 +18,6 @@ metadata:
   name: clients.client-name # kpt-set: clients.${client-name}
   namespace: hierarchy
 spec:
-  displayName: client-name # kpt-set: ${client-name}
+  displayName: client-folder-display-name # kpt-set: ${client-folder-display-name}
   folderRef:
     name: clients

--- a/solutions/experimentation/client-landing-zone/setters.yaml
+++ b/solutions/experimentation/client-landing-zone/setters.yaml
@@ -42,6 +42,10 @@ data:
   # customization: required
   client-name: 'client1'
   #
+  # Client folder display name
+  # customization: required
+  client-folder-display-name: client-folder-display-name
+  #
   # group to grant viewer permission on client folder
   # customization: required
   client-folderviewer: 'group:client1@example.com'


### PR DESCRIPTION
closes #897 

adding a setters for client-folder-display-name into the experimentation/client-landing-zone package