### PR TITLE
fix: update core dns project setter name

### DIFF
--- a/solutions/client-setup/README.md
+++ b/solutions/client-setup/README.md
@@ -18,7 +18,7 @@ Package to setup a client's namespaces, folder, management project and root sync
 | client-folder-display-name   | client-folder-display-name      | str  |     1 |
 | client-management-project-id | client-management-project-12345 | str  |   111 |
 | client-name                  | client1                         | str  |   148 |
-| dns-project-id               | dns-project-12345               | str  |     1 |
+| core-dns-project-id          | core-dns-project-12345          | str  |     2 |
 | management-namespace         | config-control                  | str  |    27 |
 | management-project-id        | management-project-12345        | str  |     6 |
 | management-project-number    |                      0000000000 | str  |     1 |
@@ -78,7 +78,7 @@ This package has no sub-packages.
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-networkadmin-permissions                                     | hierarchy                  |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-security-permissions                                         | hierarchy                  |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-dns-permissions                                              | hierarchy                  |
-| namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-tier2-dns-record-admin-permission                            | projects                   |
+| namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-tier2-dns-record-admin-core-dns-project-id-permissions       | projects                   |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-service-control-permissions                                  | hierarchy                  |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-xpnadmin-permissions                                         | config-control             |
 | namespaces/client-name-networking.yaml           | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | client-name-networking-sa-servicedirectoryeditor-permissions                           | hierarchy                  |

--- a/solutions/client-setup/namespaces/client-name-networking.yaml
+++ b/solutions/client-setup/namespaces/client-name-networking.yaml
@@ -86,7 +86,7 @@ spec:
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: client-name-networking-sa-tier2-dns-record-admin-permission # kpt-set: ${client-name}-networking-sa-tier2-dns-record-admin-permission
+  name: client-name-networking-sa-tier2-dns-record-admin-core-dns-project-id-permissions # kpt-set: ${client-name}-networking-sa-tier2-dns-record-admin-${core-dns-project-id}-permissions
   namespace: projects
   annotations:
     cnrm.cloud.google.com/ignore-clusterless: "true"
@@ -95,7 +95,7 @@ spec:
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
-    name: dns-project-id # kpt-set: ${dns-project-id}
+    name: core-dns-project-id # kpt-set: ${core-dns-project-id}
   # AC-1, AC-3, AC-3(7), AC-16(2)
   role: organizations/org-id/roles/tier2.dnsrecord.admin # kpt-set: organizations/${org-id}/roles/tier2.dnsrecord.admin
   member: "serviceAccount:client-name-networking-sa@client-management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:${client-name}-networking-sa@${client-management-project-id}.iam.gserviceaccount.com

--- a/solutions/client-setup/securitycontrols.md
+++ b/solutions/client-setup/securitycontrols.md
@@ -7,6 +7,7 @@
 |AC-1|./namespaces/client-name-admin.yaml|allow-resource-reference-from-client-name-admin|
 |AC-1|./namespaces/client-name-admin.yaml|allow-resource-reference-from-client-name-networking|
 |AC-1|./namespaces/client-name-admin.yaml|allow-resource-reference-from-client-name-projects|
+|AC-1|./namespaces/client-name-admin.yaml|client-name-admin-sa|
 |AC-1|./namespaces/client-name-admin.yaml|client-name-admin-sa-workload-identity-binding|
 |AC-1|./namespaces/client-name-hierarchy.yaml|allow-client-name-hierarchy-resource-reference-from-policies|
 |AC-1|./namespaces/client-name-hierarchy.yaml|allow-resource-reference-from-client-name-hierarchy|
@@ -36,7 +37,7 @@
 |AC-1|./namespaces/client-name-networking.yaml|client-name-networking-sa-security-permissions|
 |AC-1|./namespaces/client-name-networking.yaml|client-name-networking-sa-service-control-permissions|
 |AC-1|./namespaces/client-name-networking.yaml|client-name-networking-sa-servicedirectoryeditor-permissions|
-|AC-1|./namespaces/client-name-networking.yaml|client-name-networking-sa-tier2-dns-record-admin-permission|
+|AC-1|./namespaces/client-name-networking.yaml|client-name-networking-sa-tier2-dns-record-admin-core-dns-project-id-permissions|
 |AC-1|./namespaces/client-name-networking.yaml|client-name-networking-sa-workload-identity-binding|
 |AC-1|./namespaces/client-name-networking.yaml|client-name-networking-sa-xpnadmin-permissions|
 |AC-1|./namespaces/client-name-projects.yaml|allow-resource-reference-from-projects|
@@ -91,7 +92,7 @@
 |AC-16(2)|./namespaces/client-name-networking.yaml|client-name-networking-sa-security-permissions|
 |AC-16(2)|./namespaces/client-name-networking.yaml|client-name-networking-sa-service-control-permissions|
 |AC-16(2)|./namespaces/client-name-networking.yaml|client-name-networking-sa-servicedirectoryeditor-permissions|
-|AC-16(2)|./namespaces/client-name-networking.yaml|client-name-networking-sa-tier2-dns-record-admin-permission|
+|AC-16(2)|./namespaces/client-name-networking.yaml|client-name-networking-sa-tier2-dns-record-admin-core-dns-project-id-permissions|
 |AC-16(2)|./namespaces/client-name-networking.yaml|client-name-networking-sa-workload-identity-binding|
 |AC-16(2)|./namespaces/client-name-networking.yaml|client-name-networking-sa-xpnadmin-permissions|
 |AC-16(2)|./namespaces/client-name-networking.yaml|configconnectorcontext.core.cnrm.cloud.google.com|
@@ -149,7 +150,7 @@
 |AC-3|./namespaces/client-name-networking.yaml|client-name-networking-sa-security-permissions|
 |AC-3|./namespaces/client-name-networking.yaml|client-name-networking-sa-service-control-permissions|
 |AC-3|./namespaces/client-name-networking.yaml|client-name-networking-sa-servicedirectoryeditor-permissions|
-|AC-3|./namespaces/client-name-networking.yaml|client-name-networking-sa-tier2-dns-record-admin-permission|
+|AC-3|./namespaces/client-name-networking.yaml|client-name-networking-sa-tier2-dns-record-admin-core-dns-project-id-permissions|
 |AC-3|./namespaces/client-name-networking.yaml|client-name-networking-sa-workload-identity-binding|
 |AC-3|./namespaces/client-name-networking.yaml|client-name-networking-sa-xpnadmin-permissions|
 |AC-3|./namespaces/client-name-networking.yaml|configconnectorcontext.core.cnrm.cloud.google.com|
@@ -207,7 +208,7 @@
 |AC-3(7)|./namespaces/client-name-networking.yaml|client-name-networking-sa-security-permissions|
 |AC-3(7)|./namespaces/client-name-networking.yaml|client-name-networking-sa-service-control-permissions|
 |AC-3(7)|./namespaces/client-name-networking.yaml|client-name-networking-sa-servicedirectoryeditor-permissions|
-|AC-3(7)|./namespaces/client-name-networking.yaml|client-name-networking-sa-tier2-dns-record-admin-permission|
+|AC-3(7)|./namespaces/client-name-networking.yaml|client-name-networking-sa-tier2-dns-record-admin-core-dns-project-id-permissions|
 |AC-3(7)|./namespaces/client-name-networking.yaml|client-name-networking-sa-workload-identity-binding|
 |AC-3(7)|./namespaces/client-name-networking.yaml|client-name-networking-sa-xpnadmin-permissions|
 |AC-3(7)|./namespaces/client-name-networking.yaml|configconnectorcontext.core.cnrm.cloud.google.com|

--- a/solutions/client-setup/setters.yaml
+++ b/solutions/client-setup/setters.yaml
@@ -108,7 +108,7 @@ data:
   #
   # dns project id created during core-landing-zone package deployment
   # customization: required, obtain value from the core-landing-zone setters.yaml
-  dns-project-id: dns-project-12345
+  core-dns-project-id: core-dns-project-12345
   #
   ##########################
   # Labels


### PR DESCRIPTION
supports #883 

- rename setter `dns-project-id` to `core-dns-project-id` for consistency
- rename the permission name using that setter to include the id to minimize immutable field errors when values change